### PR TITLE
When passing a list to @each as a variable it acts as a string.

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -517,7 +517,7 @@ class scssc {
 			return $this->reduce($child[1], true);
 		case "each":
 			list(,$each) = $child;
-			$list = $this->reduce($this->coerceList($each->list));
+			$list = $this->coerceList($this->reduce($each->list));
 			foreach ($list[2] as $item) {
 				$this->pushEnv();
 				$this->set($each->var, $item);

--- a/tests/inputs/looping.scss
+++ b/tests/inputs/looping.scss
@@ -1,12 +1,22 @@
 
 div {
-    @each $var in what is this {
-        color: $var;
-    }
+	@each $var in what is this {
+		color: $var;
+	}
 
-    @each $var in what, is, this {
-        font: $var;
-    }
+	@each $var in what, is, this {
+		font: $var;
+	}
+
+	$list: what is this;
+	@each $var in $list {
+	   background: $var;
+	}
+
+	$list: what, is, this;
+	@each $var in $list {
+		border: $var;
+	}
 }
 
 

--- a/tests/outputs/looping.css
+++ b/tests/outputs/looping.css
@@ -4,7 +4,13 @@ div {
   color: this;
   font: what;
   font: is;
-  font: this; }
+  font: this;
+  background: what;
+  background: is;
+  background: this;
+  border: what;
+  border: is;
+  border: this; }
 
 span {
   color: 0;


### PR DESCRIPTION
Using http://sass-lang.com/try.html on this code:

```
$list: 0 1 2 3;
@each $n in $list { .item-#{$n} {color: black;} }
```

Returns:

```
.item-0 {
  color: black; }

.item-1 {
  color: black; }

.item-2 {
  color: black; }

.item-3 {
  color: black; }
```

And when using scssphp I receive:

```
.item-0 1 2 3 {
  color: black; }
```

But when using:

```
@each $n in 0 1 2 3 { .item-#{$n} {color: black;} }
```

They both work as expected (creating four different rules)

Created a fix here (along with testing): https://github.com/iMoses/scssphp
