### PR TITLE
Add pscss as bin in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,6 @@
     "require-dev": {
         "php": ">=5.3.0",
         "phpunit/phpunit": "3.7.*"
-    }
+    },
+    "bin": ["pscss"]
 }


### PR DESCRIPTION
This _really_ simple patch adds the `pscss` as a [bin](http://getcomposer.org/doc/04-schema.md#bin) in composer.json.

Other projects consuming scssphp will thus receive a `vendor/bin/pscss` file as expected.

Besides, I also needed this in order to automatically bundle scssphp as a phar (https://github.com/clue/phar-composer).
