### PR TITLE
Expose methods required to create custom/external serve()

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -4233,7 +4233,7 @@ class scss_server {
 	 *
 	 * @return string
 	 */
-	protected function cacheName($fname) {
+	public function cacheName($fname) {
 		return $this->join($this->cacheDir, md5($fname) . '.css');
 	}
 
@@ -4254,7 +4254,7 @@ class scss_server {
 	 *
 	 * @return boolean True if compile required.
 	 */
-	protected function needsCompile($in, $out) {
+	public function needsCompile($in, $out) {
 		if (!is_file($out)) return true;
 
 		$mtime = filemtime($out);
@@ -4279,7 +4279,7 @@ class scss_server {
 	 *
 	 * @return string
 	 */
-	protected function compile($in, $out) {
+	public function compile($in, $out) {
 		$start = microtime(true);
 		$css = $this->scss->compile(file_get_contents($in), $in);
 		$elapsed = round((microtime(true) - $start), 4);


### PR DESCRIPTION
...serve() method

I have done this in order create my own serve() method. The method I have created is based on the existing one but has been altered to be compatible with CodeIgniter which manages output itself thus preventing the use of echo and header();
