### PR TITLE
Made findImport method public to enable usage from outside

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -1533,7 +1533,7 @@ class scssc {
 	}
 
 	// results the file path for an import url if it exists
-	protected function findImport($url) {
+	public function findImport($url) {
 		$urls = array();
 
 		// for "normal" scss imports (ignore vanilla css and external requests)


### PR DESCRIPTION
For another PR I'll reference as soon as I created it, I needed the findImport method to be public
