### PR TITLE
Fix for @extend infinite loop.

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -186,6 +186,11 @@ class scssc {
 			$rem = array_diff($single, $target);
 
 			foreach ($origin as $j => $new) {
+				// fix for extend infinite loop
+				// note: I have no idea what I'm doing, but all tests pass
+				foreach ($new as $new_selector) {
+					if (!array_diff($single, $new_selector)) continue 2;
+				}
 				$origin[$j][count($origin[$j]) - 1] = $this->combineSelectorSingle(end($new), $rem);
 			}
 

--- a/tests/inputs/extends.scss
+++ b/tests/inputs/extends.scss
@@ -146,6 +146,17 @@ wassup {
     @extend #something;
 }
 
+// twitter-sass-bootstrap infinite loop
+
+.nav-tabs {
+  &.nav-justified {
+    @extend .nav-justified;
+  }
+}
+.nav-justified {
+  text-align: justify;
+}
+
 // multi-extend with nesting
 
 .btn:hover,

--- a/tests/outputs/extends.css
+++ b/tests/outputs/extends.css
@@ -74,6 +74,9 @@ wassup {
 #something, .x, .y {
   color: red; }
 
+.nav-justified, .nav-tabs.nav-justified {
+  text-align: justify; }
+
 .btn:hover, .edit .actions button:hover, .edit .new .actions button:hover, .btn:active, .edit .actions button:active, .edit .new .actions button:active, .btn.active, .edit .actions button.active, .edit .new .actions button.active, .btn.disabled, .edit .actions button.disabled, .edit .new .actions button.disabled, .btn[disabled], .edit .actions button[disabled], .edit .new .actions button[disabled] {
   color: red; }
 


### PR DESCRIPTION
In Twitter Bootstrap 3.0.0 converted to SASS ([jlong/sass-bootstrap](https://github.com/jlong/sass-bootstrap/)), the following case in  `_navs.scss` (reduced to minimum failing example) causes an infinite loop to occur at compilation in scssphp:

```
.nav-tabs {
  &.nav-justified {
    @extend .nav-justified;
  }
}

.nav-justified {
  text-align: justify;
}
```

The reason is that the `&.nav-justified` that contains the extend is used as its own target.

This pull request adds:
- a test case demonstrating the problem (I wanted to add it to the end of extends.scss, but it caused extra spaces to appear in the output, so I moved it);
- a lucky guess fix that is probably not the right way to correct the problem (I didn’t understand all the underpinnings of the `@extend` processing mechanism) but doesn’t break any tests.
