### PR TITLE
Recursively create cache-dir with decent permissions

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -4349,7 +4349,7 @@ class scss_server {
 		}
 
 		$this->cacheDir = $cacheDir;
-		if (!is_dir($this->cacheDir)) mkdir($this->cacheDir);
+		if (!is_dir($this->cacheDir)) mkdir($this->cacheDir, 0755, true);
 
 		if (is_null($scss)) {
 			$scss = new scssc();


### PR DESCRIPTION
I try to consolidate all my disk-based caches under a single parent folder and noticed that this one was having trouble being created. This patch will make it so that parent directories of the cache directory are created automatically. In addition, it ensures that group/other users do not have write permissions to the cache directory or its parents.
