### PR TITLE
added salt to cache name + added a public method for fetching variables

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -1513,6 +1513,10 @@ class scssc {
 		unset($this->userFunctions[$this->normalizeName($name)]);
 	}
 
+    public function getVariable($name, $defaultValue = null, $env = null) {
+        return $this->get($name, $defaultValue, $env);
+    }
+
 	protected function importFile($path, $out) {
 		// see if tree is cached
 		$realPath = realpath($path);
@@ -4308,10 +4312,12 @@ class scss_server {
 
 	/**
 	 * Compile requested scss and serve css.  Outputs HTTP response.
+     *
+     * @param string $salt Prefix a string to the filename for creating the cache name hash
 	 */
-	public function serve() {
+	public function serve($salt = null) {
 		if ($input = $this->findInput()) {
-			$output = $this->cacheName($input);
+			$output = $this->cacheName($salt . $input);
 			header('Content-type: text/css');
 
 			if ($this->needsCompile($input, $output)) {


### PR DESCRIPTION
1. When deploying our site to production we came across a problem in which the scss files didn't change directly but the registered functions I've defined using the PHP code outputted a different result, causing the scss files to load from cache even though changes were made to them. I've added the `$salt` argument which allows us to add the revision to the `serve` method, thus preventing the load of old cache once the revision of the code has changed. If think that this is a good add-on, so I hope you'll pull this code to your project as well.
2. Sometimes we might need to reach scss variables from within the registered function, so I've created a porxy method `getVariable` for fetching the scss code local variables (same as `get`)
