### PR TITLE
fixes a bug when using functions in mixin_content

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -1460,12 +1460,13 @@ class scssc {
 		} elseif (!is_null($env->parent)) {
 			$this->setExisting($name, $value, $env->parent);
 		} else {
-			$this->env->store[$name] = $value;
+			$env->store[$name] = $value;
 		}
 	}
 
 	protected function setRaw($name, $value) {
-		$this->env->store[$name] = $value;
+		$env = $this->getStoreEnv();
+		$env->store[$name] = $value;
 	}
 
 	protected function get($name, $defaultValue = null, $env = null) {

--- a/tests/inputs/content_with_function.scss
+++ b/tests/inputs/content_with_function.scss
@@ -1,0 +1,17 @@
+$test-var: true;
+
+@mixin mixin-using-content() {
+    @content;
+}
+
+@function test-function($value) {
+    @return $value;
+}
+
+@include mixin-using-content {
+    @if $test-var {
+        body {
+            padding: test-function(1 px);
+        }
+    }
+}

--- a/tests/outputs/content_with_function.css
+++ b/tests/outputs/content_with_function.css
@@ -1,0 +1,2 @@
+body {
+  padding: 1 px; }


### PR DESCRIPTION
I was trying to compile the foundation 5 framework (http://foundation.zurb.com/) and got some errors with mixins using @content when the contend is using custom function. This PR fixed those issues.
