### PR TITLE
Update .gitignore to include php files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /*.scss
 /*.css
-/*.php
 .sass-cache
 /sass/
 /compass/


### PR DESCRIPTION
We are using medusa and satis to mirror several git repositories, while doing this, composers "GitExcludeFilter" removes the scss.inc.php from the resulting package.

I don't know why this made it to the gitignore in the first place, but maybe this PR is helpful for others, too.
