### PR TITLE
Tidy indentation of subsequent lines in media queries.

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -4051,9 +4051,14 @@ class scss_formatter {
 
 		$inner = $pre = $this->indentStr();
 
+		$tagSeparator = $this->tagSeparator;
+		if (false !== strpos($tagSeparator, "\n")) {
+			$tagSeparator .= $pre;
+		}
+
 		if (!empty($block->selectors)) {
 			echo $pre .
-				implode($this->tagSeparator, $block->selectors) .
+				implode($tagSeparator, $block->selectors) .
 				$this->open . $this->break;
 			$this->indentLevel++;
 			$inner = $this->indentStr();


### PR DESCRIPTION
In the status quo, if there is a multi-tag selector inside of a media
query, and the `$tagSeparator` includes a newline, the subsequent lines
aren’t indented as they should be.

Now, we clearly don’t want to just shove `$pre` in between every
selector if the `$tagSeparator` doesn’t contain a newline.

So let’s check for it, and switch to a local version of
`$this->tagSeparator` so it doesn’t mess with the full property — and
if there is a new line in the `$tagSeparator`, append it with the
`$pre` indent.