### PR TITLE
Fix issue #164 for multiline string parsing

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -3988,7 +3988,7 @@ class scss_parser {
 		$token = null;
 
 		$end = strpos($this->buffer, "\n", $this->count);
-		if ($end === false) {
+		if ($end === false || $this->buffer[$end - 2] == '\\') {
 			$end = strlen($this->buffer);
 		}
 


### PR DESCRIPTION
When parsing strings, the parser, on a newline, should look behind
for a backslash to determine if this is a multiline string.

The code below is an example of a valid CSS code that should be
compiled by scssphp without throwing an exception.

```
body:after {
    content: "This is a \
multiline string.";
}
```
