### PR TITLE
Fix string newline escaping for Windows

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -3988,7 +3988,7 @@ class scss_parser {
 		$token = null;
 
 		$end = strpos($this->buffer, "\n", $this->count);
-		if ($end === false || $this->buffer[$end - 1] == '\\') {
+		if ($end === false || $this->buffer[$end - 1] == '\\' || $this->buffer[$end - 2] == '\\' && $this->buffer[$end - 1] == "\r") {
 			$end = strlen($this->buffer);
 		}
 


### PR DESCRIPTION
As per discussion in #164, this allows strings with `\\n` and `\\n\r` before the string delimiter.
