### PR TITLE
Fixes include of scss.inc.php in the script

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -3,7 +3,7 @@
 
 error_reporting(E_ALL);
 
-include 'scss.inc.php';
+include __DIR__.'/../scss.inc.php';
 
 use Leafo\ScssPhp\Compiler;
 use Leafo\ScssPhp\Parser;


### PR DESCRIPTION
In my project we use scssphp and came to a point where we needed to use the script.

And we have scssphp installed with composer, so of course we don't stand in `vendor/leafo/scssphp/` when we run `vendor/bin/pscss`.

This patch changes so you can stand in any directory and run the script.

Reason for this not been detected before is probably that everyone testing it have been standing in the root of a scssphp checkout. PHP has `.` in the include path, and this `.` is where the shell is standing.
