### PR TITLE
[ ETAG ] Don't compare meta-etag with browser etag

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -119,10 +119,6 @@ class Server
         if (is_readable($metadataName)) {
             $metadata = unserialize(file_get_contents($metadataName));
 
-            if ($metadata['etag'] === $etag) {
-                return false;
-            }
-
             foreach ($metadata['imports'] as $import) {
                 if (filemtime($import) > $mtime) {
                     return true;


### PR DESCRIPTION
In most cases the browser’s ETAG will be the same with one in the meta
file, event if the files are changed in the mean while, thus it will
always return a 302