### PR TITLE
Fix the return value in case of a parse error

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -230,13 +230,14 @@ class Server
 
                     echo $css;
 
-                    return;
                 } catch (\Exception $e) {
                     header($protocol . ' 500 Internal Server Error');
                     header('Content-type: text/plain');
 
                     echo 'Parse error: ' . $e->getMessage() . "\n";
                 }
+
+                return;
             }
 
             header('X-SCSS-Cache: true');


### PR DESCRIPTION
Without the return, the server renders a 304 Not Modified if there's an error