### PR TITLE
Added ability to @import files once only. $scss->setImportOnce(true);

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -93,6 +93,7 @@ class Compiler
 
     protected $importPaths = array('');
     protected $importCache = array();
+	protected $importOnce = false;
 
     protected $userFunctions = array();
     protected $registeredVars = array();
@@ -1931,6 +1932,11 @@ class Compiler
         $this->importPaths = (array)$path;
     }
 
+    public function setImportOnce($importOnce = false)
+    {
+        $this->importOnce = $importOnce;
+    }
+
     public function setNumberPrecision($numberPrecision)
     {
         $this->numberPrecision = $numberPrecision;
@@ -1956,7 +1962,8 @@ class Compiler
         // see if tree is cached
         $realPath = realpath($path);
         if (isset($this->importCache[$realPath])) {
-            $tree = $this->importCache[$realPath];
+			if ( !$this->importOnce )
+	            $tree = $this->importCache[$realPath];
         } else {
             $code = file_get_contents($path);
             $parser = new Parser($path, false);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1962,8 +1962,9 @@ class Compiler
         // see if tree is cached
         $realPath = realpath($path);
         if (isset($this->importCache[$realPath])) {
-			if ( !$this->importOnce )
-	            $tree = $this->importCache[$realPath];
+			if ( $this->importOnce )
+				return;
+            $tree = $this->importCache[$realPath];
         } else {
             $code = file_get_contents($path);
             $parser = new Parser($path, false);


### PR DESCRIPTION
For those situations where scss files are being imported repeatedly and you only want to import each one once. In my case, compiling Zurb Foundation 5, it reduced the resulting CSS by 60%.

Usage:
    $scss = new scssc();
    $scss->setImportOnce(true);

Default:
    false

Compiler will work as before unless it is overridden.