### PR TITLE
Update precision to support bootstrap

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -97,7 +97,7 @@ class Compiler
     protected $userFunctions = array();
     protected $registeredVars = array();
 
-    protected $numberPrecision = 5;
+    protected $numberPrecision = 10;
 
     protected $formatter = 'Leafo\ScssPhp\Formatter\Nested';
 


### PR DESCRIPTION
Per http://stackoverflow.com/questions/23971428/twitter-bootstrap-3-button-1px-too-small , the precision for this must be at least 10 in order to render bootstrap correctly. In lieu of making this a configurable value of some sort, just set it to 10. It should not have a performance impact, that I can see.