### PR TITLE
Maps

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -844,7 +844,14 @@ class Compiler
                 $list = $this->coerceList($this->reduce($each->list));
                 foreach ($list[2] as $item) {
                     $this->pushEnv();
-                    $this->set($each->var, $item);
+                    if (count($each->vars) == 1) {
+                        $this->set($each->vars[0], $item);
+                    } else {
+                        list(,,$values) = $this->coerceList($item);
+                        foreach ($each->vars as $i => $var) {
+                            $this->set($var, isset($values[$i]) ? $values[$i] : self::$null);
+                        }
+                    }
                     // TODO: allow return from here
                     $this->compileChildren($each->children, $out);
                     $this->popEnv();

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1517,6 +1517,19 @@ class Compiler
                 }
 
                 return implode("$delim ", $filtered);
+            case 'map':
+                $map = $value[1];
+
+                $filtered = array();
+                foreach ($map as $key => $item) {
+                    if ($item[0] == 'null') {
+                        continue;
+                    }
+
+                    $filtered[] = $key . ': ' . $this->compileValue($item);
+                }
+
+                return '(' . implode(", ", $filtered) . ')';
             case 'interpolated': # node created by extractInterpolation
                 list(, $interpolate, $left, $right) = $value;
                 list(,, $whiteLeft, $whiteRight) = $interpolate;
@@ -1683,6 +1696,17 @@ class Compiler
     {
         if (isset($item) && $item[0] == 'list') {
             return $item;
+        }
+
+        if (isset($item) && $item[0] == 'map') {
+            $map = $item[1];
+            $list = array();
+
+            foreach ($map as $key => $value) {
+                $list[] = array('list', '', array(array('keyword', $key), $value));
+            }
+
+            return array('list', ',', $list);
         }
 
         return array('list', $delim, !isset($item) ? array(): array($item));
@@ -2859,6 +2883,64 @@ class Compiler
         return isset($list[2][$n]) ? $list[2][$n] : self::$defaultValue;
     }
 
+    protected static $libMapGet = array('map', 'key');
+    protected function libMapGet($args)
+    {
+        $map = $args[0];
+        $key = $this->compileStringContent($this->coerceString($args[1]));
+
+        return isset($map[1][$key]) ? $map[1][$key] : self::$defaultValue;
+    }
+
+    protected static $libMapKeys = array('map');
+    protected function libMapKeys($args)
+    {
+        $map = $args[0][1];
+        $keys = array();
+        foreach (array_keys($map) as $key) {
+            $keys[] = array('keyword', $key);
+        }
+
+        return array('list', ',', $keys);
+    }
+
+    protected static $libMapValues = array('map');
+    protected function libMapValues($args)
+    {
+        $map = $args[0][1];
+
+        return array('list', ',', array_values($map));
+    }
+
+    protected static $libMapRemove = array('map', 'key');
+    protected function libMapRemove($args)
+    {
+        $map = $args[0][1];
+        $key = $this->compileStringContent($this->coerceString($args[1]));
+
+        unset($map[$key]);
+
+        return array('map', $map);
+    }
+
+    protected static $libMapHasKey = array('map', 'key');
+    protected function libMapHasKey($args)
+    {
+        $map = $args[0][1];
+        $key = $this->compileStringContent($this->coerceString($args[1]));
+
+        return isset($map[$key]) ? self::$true : self::$false;
+    }
+
+
+    protected static $libMapMerge = array('map-1', 'map-2');
+    protected function libMapMerge($args)
+    {
+        $map1 = $args[0][1];
+        $map2 = $args[1][1];
+
+        return array('map', array_merge($map1, $map2));
+    }
     protected function listSeparatorForJoin($list1, $sep)
     {
         if (!isset($sep)) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -254,13 +254,15 @@ class Parser
             $this->seek($s);
 
             if ($this->literal('@each') &&
-                $this->variable($varName) &&
+                $this->genericList($varNames, 'variable', ',', false) &&
                 $this->literal('in') &&
                 $this->valueList($list) &&
                 $this->literal('{')
             ) {
                 $each = $this->pushSpecialBlock('each');
-                $each->var = $varName[1];
+                foreach ($varNames[2] as $varName) {
+                    $each->vars[] = $varName[1];
+                }
                 $each->list = $list;
 
                 return true;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -783,6 +783,10 @@ class Parser
             }
 
             $this->seek($s);
+
+            if ($this->map($out)) {
+                return true;
+            }
         }
 
         if ($this->value($lhs)) {
@@ -1068,6 +1072,32 @@ class Parser
         }
 
         $out = $args;
+
+        return true;
+    }
+
+    protected function map(&$out)
+    {
+        $s = $this->seek();
+        $this->literal('(');
+
+        $map = array();
+
+        while ($this->keyword($key) && $this->literal(':') && $this->genericList($value, 'expression')) {
+            $map[$key] = $value;
+
+            if (!$this->literal(',')) {
+                break;
+            }
+        }
+
+        if (!count($map) || !$this->literal(')')) {
+            $this->seek($s);
+
+            return false;
+        }
+
+        $out = array('map', $map);
 
         return true;
     }

--- a/tests/inputs/looping.scss
+++ b/tests/inputs/looping.scss
@@ -17,6 +17,14 @@ div {
 	@each $var in $list {
 		border: $var;
 	}
+
+	@each $var in what what, is is, this this {
+		background: $var;
+	}
+
+	@each $var in (what: what, is: is, this: this) {
+		background: $var;
+	}
 }
 
 

--- a/tests/inputs/looping.scss
+++ b/tests/inputs/looping.scss
@@ -25,6 +25,13 @@ div {
 	@each $var in (what: what, is: is, this: this) {
 		background: $var;
 	}
+
+	@each $header, $size, $nonexistent in (h1: 2em, h2: 1.5em, h3: 1.2em) {
+ 		#{$header} {
+ 			font-size: $size;
+ 			border: $nonexistent;
+ 		}
+ 	}
 }
 
 

--- a/tests/inputs/map.scss
+++ b/tests/inputs/map.scss
@@ -1,0 +1,26 @@
+$map: (
+    color: black,
+    color2: red,
+    color3: #00FF00
+);
+$map2: (
+    color: rgb(255, 255, 255),
+    length: 40em
+);
+
+// Map functions
+div {
+    color: map_get($map, color);
+    color: map_get($map, 'color#{2}');
+    foo: map_values($map);
+    bar: map_keys($map2);
+    baz: map_merge($map, $map2);
+    foo: map_remove($map2, color);
+    bar: if(map_has_key($map, color), true, false);
+}
+
+// List functions
+div {
+    foo: nth($map, 1);
+    bar: nth(nth($map, 1), 1);
+}

--- a/tests/outputs/looping.css
+++ b/tests/outputs/looping.css
@@ -10,7 +10,13 @@ div {
   background: this;
   border: what;
   border: is;
-  border: this; }
+  border: this;
+  background: what what;
+  background: is is;
+  background: this this;
+  background: what what;
+  background: is is;
+  background: this this; }
 
 span {
   color: 0;

--- a/tests/outputs/looping.css
+++ b/tests/outputs/looping.css
@@ -17,6 +17,12 @@ div {
   background: what what;
   background: is is;
   background: this this; }
+  div h1 {
+    font-size: 2em; }
+  div h2 {
+    font-size: 1.5em; }
+  div h3 {
+    font-size: 1.2em; }
 
 span {
   color: 0;

--- a/tests/outputs/map.css
+++ b/tests/outputs/map.css
@@ -1,0 +1,12 @@
+div {
+  color: black;
+  color: red;
+  foo: black, red, #0f0;
+  bar: color, length;
+  baz: (color: #fff, color2: red, color3: #0f0, length: 40em);
+  foo: (length: 40em);
+  bar: true; }
+
+div {
+  foo: color black;
+  bar: color; }

--- a/tests/outputs/scss_css.css
+++ b/tests/outputs/scss_css.css
@@ -5,6 +5,8 @@
 @import url(foo.css);
 @import "foo.css" screen;
 @import "foo.css" screen, print;
+@import "foo.css" screen, print and (foo: 0);
+@import "foo.css" screen, only print, screen and (foo: 0);
 @charset "UTF-8";
 [foo~=bar] {
   a: b; }
@@ -202,10 +204,6 @@ foo {
 foo {
   a: foo-bar(12);
   b: -foo-bar-baz(13, 14 15); }
-
-@import "foo.css" screen, print and (foo: 0);
-
-@import "foo.css" screen, only print, screen and (foo: 0);
 
 foo {
   a: foo !important;


### PR DESCRIPTION
This adds support for maps (#192) and for multiple assignment in `@each` (one of their main usages). The parsed representation is `array('map', $map)` where `$map` is an native array of keys to parsed values. List functions are supported through an extension to the coerceList() method.

Unlike the ruby implementation, but like most of scssphp, maps can be output directly to CSS, even though they are not valid CSS.

This also fixes a bug with media queries on imports, as media features are now parsed as maps.