### PR TITLE
Don't call autoloader when checking if class exists

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -3,7 +3,7 @@ if (version_compare(PHP_VERSION, '5.3') < 0) {
     die('Requires PHP 5.3 or above');
 }
 
-if ( ! class_exists('scssc')) {
+if ( ! class_exists('scssc', false)) {
     include_once __DIR__ . '/src/Base/Range.php';
     include_once __DIR__ . '/src/Colors.php';
     include_once __DIR__ . '/src/Compiler.php';


### PR DESCRIPTION
I ran into an issue when including `scss.inc.php` where a silly autoloader started logging errors about missing the file `Scssc.php`. A little bit unsure about the reason for `class_exists` but I assume it should be safe to ignore calling autoloaders here.