### PR TITLE
Add gitattributes w/ export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Ignore un-needed files and directories for export of production releases
+# Keeps src/
+#
+# See: http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Exporting-Your-Repository
+
+tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+box.json.dist export-ignore
+Makefile export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
This will allow for a production ready version of scssphp when archived/exported for release(s) and still allowing a development version within the repository.

The `export-ignore` excludes un-needed files and directories when a branch is archived for release but these files are still included when the repo is cloned/forked.

This would be very useful because releases are intended for production use and when users are using a package (via composer or zip), they most likely are not interested in downloading the source code as a whole into production, thus saving server disk space and meeting security protocol. Think of it as a .gitignore for releases.

  - e.g. /tests folder, or your .travis.yml file, etc. will not be included in the release zip(s)

See: [git-scm.com - Exporting-Your-Repository](http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Exporting-Your-Repository)