### PR TITLE
Only divide by 100 if number is truly a percent

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3752,7 +3752,7 @@ class Compiler
     protected function coercePercent($value)
     {
         if ($value[0] === Type::T_NUMBER) {
-            if (isset($value[2]['%'])) {
+            if (!empty($value[2]['%'])) {
                 return $value[1] / 100;
             }
 

--- a/tests/inputs/builtins.scss
+++ b/tests/inputs/builtins.scss
@@ -104,6 +104,7 @@
 
 #number {
     color: percentage(100/40);
+    $test: 50%; $test: 0 + ($test / 100%); color: percentage($test);
     color: round(3.4);
     color: floor(3.4);
     color: ceil(3.4);

--- a/tests/outputs/builtins.css
+++ b/tests/outputs/builtins.css
@@ -76,6 +76,7 @@
 
 #number {
   color: 250%;
+  color: 50%;
   color: 3;
   color: 3;
   color: 4;

--- a/tests/outputs_numbered/builtins.css
+++ b/tests/outputs_numbered/builtins.css
@@ -77,6 +77,7 @@
 /* line 105, inputs/builtins.scss */
 #number {
   color: 250%;
+  color: 50%;
   color: 3;
   color: 3;
   color: 4;
@@ -85,7 +86,7 @@
   width: 200%;
   bottom: 10px;
   padding: 3em 1in 96px 72pt; }
-/* line 118, inputs/builtins.scss */
+/* line 119, inputs/builtins.scss */
 #list {
   len: 3;
   len: 1;
@@ -107,7 +108,7 @@
   cool: great job one two three;
   zip: 1px solid, 2px dashed;
   zip: 1px solid red, 2px dashed green; }
-/* line 154, inputs/builtins.scss */
+/* line 155, inputs/builtins.scss */
 #introspection {
   t: number;
   t: string;
@@ -127,35 +128,35 @@
   c: true;
   c: false;
   c: true; }
-/* line 178, inputs/builtins.scss */
+/* line 179, inputs/builtins.scss */
 #if {
   color: yes;
   color: no;
   color: yes;
   color: yes; }
-/* line 185, inputs/builtins.scss */
+/* line 186, inputs/builtins.scss */
 .transparent {
   r: 0;
   g: 0;
   b: 0;
   a: 0; }
-/* line 192, inputs/builtins.scss */
+/* line 193, inputs/builtins.scss */
 .alpha {
   a: 1;
   a: 1;
   a: 1;
   a: 0.5;
   a: alpha(currentColor); }
-/* line 201, inputs/builtins.scss */
+/* line 202, inputs/builtins.scss */
 #exists {
   a: true;
   b: true;
   c: false; }
-/* line 208, inputs/builtins.scss */
+/* line 209, inputs/builtins.scss */
 div.call-tests {
   a: #0a64ff;
   b: #0058ef;
   c: b; }
-/* line 215, inputs/builtins.scss */
+/* line 216, inputs/builtins.scss */
 div.unquote-test {
   a: [type='text']; }


### PR DESCRIPTION
I ran into an odd scenario with my company's codebase when I upgraded from 0.3.3 to 0.6.2. I haven't followed all of the logic that's happening to actually populate variables, but from using xdebug, it seems like a variable's unit doesn't does not always get unset, but instead set to `false` or `0`.

I included an update to the unit tests for this scenario, but I'll include it here, too. It's a vastly simplified version of what is breaking in our code.

```
$test: 50%; 
$test: 0 + ($test / 100%); // Adding zero coerces to a number, might not be necessary
color: percentage($test);

// Expected result: 50%
// Actual result: 0.5%
```

There might be a better solution to this, but this is what is working for me.