### PR TITLE
Fix #413 handling for font shorthand syntax

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1465,7 +1465,7 @@ class Compiler
                     $isGlobal = in_array('!global', $flags);
 
                     if ($isGlobal) {
-                        $this->set($name[1], $this->reduce($value), false, $this->rootEnv);
+                        $this->set($name[1], $this->reduce($value), false, $this->rootEnv, $value);
                         break;
                     }
 
@@ -1474,7 +1474,7 @@ class Compiler
                         || $result === self::$null);
 
                     if (! $isDefault || $shouldSet) {
-                        $this->set($name[1], $this->reduce($value));
+                        $this->set($name[1], $this->reduce($value), false, null, $value);
                     }
                     break;
                 }
@@ -1483,10 +1483,23 @@ class Compiler
 
                 // handle shorthand syntax: size / line-height
                 if ($compiledName === 'font') {
-                    if ($value[0] === Type::T_EXPRESSION && $value[1] === '/') {
-                        $value = $this->expToString($value);
-                    } elseif ($value[0] === Type::T_LIST) {
-                        foreach ($value[2] as &$item) {
+                    if($value[0] === Type::T_VARIABLE) {
+                        // if the font value comes from variable, the content is already reduced (which means formulars where already calculated)
+                        // so we need the original unreduced value
+                        $value = $this->get($value[1], true, null, true);
+                    }
+
+                    $fontValue=&$value;
+                    if ($value[0] === Type::T_LIST && $value[1]==',') {
+                        // this is the case if more than one font is given: example: "font: 400 1em/1.3 arial,helvetica"
+                        // we need to handle the first list element
+                        $fontValue=&$value[2][0];
+                    }
+
+                    if ($fontValue[0] === Type::T_EXPRESSION && $fontValue[1] === '/') {
+                        $fontValue = $this->expToString($fontValue);
+                    } elseif ($fontValue[0] === Type::T_LIST) {
+                        foreach ($fontValue[2] as &$item) {
                             if ($item[0] === Type::T_EXPRESSION && $item[1] === '/') {
                                 $item = $this->expToString($item);
                             }
@@ -2862,8 +2875,9 @@ class Compiler
      * @param mixed                               $value
      * @param boolean                             $shadow
      * @param \Leafo\ScssPhp\Compiler\Environment $env
+     * @param mixed                               $valueUnreduced
      */
-    protected function set($name, $value, $shadow = false, Environment $env = null)
+    protected function set($name, $value, $shadow = false, Environment $env = null, $valueUnreduced = null)
     {
         $name = $this->normalizeName($name);
 
@@ -2872,9 +2886,9 @@ class Compiler
         }
 
         if ($shadow) {
-            $this->setRaw($name, $value, $env);
+            $this->setRaw($name, $value, $env, $valueUnreduced);
         } else {
-            $this->setExisting($name, $value, $env);
+            $this->setExisting($name, $value, $env, $valueUnreduced);
         }
     }
 
@@ -2884,8 +2898,9 @@ class Compiler
      * @param string                              $name
      * @param mixed                               $value
      * @param \Leafo\ScssPhp\Compiler\Environment $env
+     * @param mixed                               $valueUnreduced
      */
-    protected function setExisting($name, $value, Environment $env)
+    protected function setExisting($name, $value, Environment $env, $valueUnreduced = null)
     {
         $storeEnv = $env;
 
@@ -2910,6 +2925,7 @@ class Compiler
         }
 
         $env->store[$name] = $value;
+        if ($valueUnreduced) $env->storeUnreduced[$name] = $valueUnreduced;
     }
 
     /**
@@ -2918,10 +2934,12 @@ class Compiler
      * @param string                              $name
      * @param mixed                               $value
      * @param \Leafo\ScssPhp\Compiler\Environment $env
+     * @param mixed                               $valueUnreduced
      */
-    protected function setRaw($name, $value, Environment $env)
+    protected function setRaw($name, $value, Environment $env, $valueUnreduced = null)
     {
         $env->store[$name] = $value;
+        if ($valueUnreduced) $env->storeUnreduced[$name] = $valueUnreduced;
     }
 
     /**
@@ -2932,10 +2950,11 @@ class Compiler
      * @param string                              $name
      * @param boolean                             $shouldThrow
      * @param \Leafo\ScssPhp\Compiler\Environment $env
+     * @param boolean                             $unreduced
      *
      * @return mixed
      */
-    public function get($name, $shouldThrow = true, Environment $env = null)
+    public function get($name, $shouldThrow = true, Environment $env = null, $unreduced = false)
     {
         $name = $this->normalizeName($name);
 
@@ -2947,6 +2966,7 @@ class Compiler
 
         for (;;) {
             if (array_key_exists($name, $env->store)) {
+                if ($unreduced && isset($env->storeUnreduced[$name])) return $env->storeUnreduced[$name];
                 return $env->store[$name];
             }
 

--- a/src/Compiler/Environment.php
+++ b/src/Compiler/Environment.php
@@ -34,6 +34,11 @@ class Environment
     public $store;
 
     /**
+     * @var array
+     */
+    public $storeUnreduced;
+
+    /**
      * @var integer
      */
     public $depth;


### PR DESCRIPTION
This would fix the issue #413
- font shorthand syntax is also recognised when multiple font-families were given and the expression is turned into a list
- font shorthand syntax is also recognised when stored in a variable (for that I always save the "unreduced" variable value too)
