### PR TITLE
Fix: "or" and "and" operators evaluates NULL as TRUE value.

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2216,7 +2216,7 @@ class Compiler
             return;
         }
 
-        if ($left !== self::$false) {
+        if ($left !== self::$false and $left !== self::$null) {
             return $this->reduce($right, true);
         }
 
@@ -2238,7 +2238,7 @@ class Compiler
             return;
         }
 
-        if ($left !== self::$false) {
+        if ($left !== self::$false and $left !== self::$null) {
             return $left;
         }
 

--- a/tests/inputs/operators.scss
+++ b/tests/inputs/operators.scss
@@ -99,10 +99,12 @@ div {
     and: (false and two);
     and: (one and two);
     and: (one and false);
+    and: (null and two);
 
     or: (false or two);
     or: (one or two);
     or: (one or false);
+    or: (null or two);
 }
 
 

--- a/tests/outputs/operators.css
+++ b/tests/outputs/operators.css
@@ -77,7 +77,8 @@ div {
   and: false;
   or: two;
   or: one;
-  or: one; }
+  or: one;
+  or: two; }
 
 #nots-fail {
   not: false2;

--- a/tests/outputs_numbered/operators.css
+++ b/tests/outputs_numbered/operators.css
@@ -78,8 +78,9 @@ div {
   and: false;
   or: two;
   or: one;
-  or: one; }
-/* line 109, inputs/operators.scss */
+  or: one;
+  or: two; }
+/* line 111, inputs/operators.scss */
 #nots-fail {
   not: false2;
   not: not false;
@@ -87,7 +88,7 @@ div {
   not: not 1;
   not: not "";
   not: not hello; }
-/* line 118, inputs/operators.scss */
+/* line 120, inputs/operators.scss */
 #nots {
   not: false2;
   not: true;
@@ -96,7 +97,7 @@ div {
   not: false;
   not: false;
   not: true; }
-/* line 128, inputs/operators.scss */
+/* line 130, inputs/operators.scss */
 #string-test {
   str: true;
   str: false;
@@ -104,72 +105,72 @@ div {
   str: true;
   str: xhellohellofalse;
   str: true; }
-/* line 144, inputs/operators.scss */
+/* line 146, inputs/operators.scss */
 #special {
   cancel-unit: 1; }
-/* line 151, inputs/operators.scss */
+/* line 153, inputs/operators.scss */
 .row .a {
   margin: -0.5em; }
-/* line 152, inputs/operators.scss */
+/* line 154, inputs/operators.scss */
 .row .b {
   margin: -0.5em; }
-/* line 153, inputs/operators.scss */
+/* line 155, inputs/operators.scss */
 .row .c {
   margin: -0.5em; }
-/* line 154, inputs/operators.scss */
+/* line 156, inputs/operators.scss */
 .row .d {
   margin: -0.5em; }
-/* line 155, inputs/operators.scss */
+/* line 157, inputs/operators.scss */
 .row .e {
   margin: 0 -0.5em; }
-/* line 157, inputs/operators.scss */
+/* line 159, inputs/operators.scss */
 .alt .a {
   margin: -0.5em; }
-/* line 158, inputs/operators.scss */
+/* line 160, inputs/operators.scss */
 .alt .b {
   margin: -0.5em; }
-/* line 159, inputs/operators.scss */
+/* line 161, inputs/operators.scss */
 .alt .c {
   margin: -0.5em; }
-/* line 160, inputs/operators.scss */
+/* line 162, inputs/operators.scss */
 .alt .d {
   margin: 0 -0.5em; }
-/* line 161, inputs/operators.scss */
+/* line 163, inputs/operators.scss */
 .alt .e {
   margin: 0 -0.5em; }
-/* line 163, inputs/operators.scss */
+/* line 165, inputs/operators.scss */
 .row .f {
   margin: -2em; }
-/* line 164, inputs/operators.scss */
+/* line 166, inputs/operators.scss */
 .row .g {
   margin: -2em; }
-/* line 165, inputs/operators.scss */
+/* line 167, inputs/operators.scss */
 .row .h {
   margin: -2em; }
-/* line 166, inputs/operators.scss */
+/* line 168, inputs/operators.scss */
 .row .i {
   margin: -2em; }
-/* line 167, inputs/operators.scss */
+/* line 169, inputs/operators.scss */
 .row .j {
   margin: 0 -2em; }
-/* line 169, inputs/operators.scss */
+/* line 171, inputs/operators.scss */
 .alt .f {
   margin: -2em; }
-/* line 170, inputs/operators.scss */
+/* line 172, inputs/operators.scss */
 .alt .g {
   margin: -2em; }
-/* line 171, inputs/operators.scss */
+/* line 173, inputs/operators.scss */
 .alt .h {
   margin: -2em; }
-/* line 172, inputs/operators.scss */
+/* line 174, inputs/operators.scss */
 .alt .i {
   margin: 0 -2em; }
-/* line 173, inputs/operators.scss */
+/* line 175, inputs/operators.scss */
 .alt .j {
   margin: 0 -2em; }
-/* line 182, inputs/operators.scss */
+/* line 184, inputs/operators.scss */
 div {
   *margin-left: 2.07447%; }
-/* line 188, inputs/operators.scss */
+/* line 190, inputs/operators.scss */
 .foo {
   width: 12.5%; }


### PR DESCRIPTION
Example:
` $a: (null or 'foo');  // $a evaluates NULL, and it shoud be 'foo'`
