### PR TITLE
Preg_match error array > string

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3621,7 +3621,7 @@ class Compiler
         }
 
         if ($value === null) {
-            $value = self::$null;
+            return self::$null;
         }
 
         if (is_numeric($value)) {


### PR DESCRIPTION
When a null value is given to coerceValue the following error is returned:
~~~
_WARNING [2]: preg_match() expects parameter 2 to be string, array given
/vendor/leafo/scssphp/src/Compiler.php, line: 3635
~~~

This change fixes that for me.