### PR TITLE
Extend resolution was generating invalid selectors

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2944,11 +2944,13 @@ class Compiler
     public function get($name, $shouldThrow = true, Environment $env = null)
     {
         $normalizedName = $this->normalizeName($name);
+        $specialContentKey = self::$namespaces['special'] . 'content';
 
         if (! isset($env)) {
             $env = $this->getStoreEnv();
         }
 
+        $nextIsRoot = false;
         $hasNamespace = $normalizedName[0] === '^' || $normalizedName[0] === '@' || $normalizedName[0] === '%';
         for (;;) {
             if (array_key_exists($normalizedName, $env->store)) {
@@ -2956,6 +2958,12 @@ class Compiler
             }
 
             if (! $hasNamespace && isset($env->marker)) {
+                if (! $nextIsRoot && !empty($env->store[$specialContentKey])) {
+                    $env = $env->store[$specialContentKey]->scope;
+                    $nextIsRoot = true;
+                    continue;
+                }
+
                 $env = $this->rootEnv;
                 continue;
             }

--- a/tests/inputs/extends.scss
+++ b/tests/inputs/extends.scss
@@ -305,3 +305,21 @@ $color-base: white;
        @extend %pagination-bullet;
     }
 }
+
+@mixin nested-foo() {
+    .in-nested-foo {
+        @content;
+    }
+}
+
+.parent-nested-foo-include {
+    @include nested-foo() {
+        .child-nested-foo-include {
+            color: green;
+        }
+    }
+}
+
+.beard + .mustache {
+    @extend .child-nested-foo-include;
+}

--- a/tests/inputs/extends_nesting.scss
+++ b/tests/inputs/extends_nesting.scss
@@ -1,0 +1,44 @@
+.btn {
+    padding: 1px;
+}
+.btn-lg {
+    font-size: 10px;
+}
+.dropup .btn-lg .caret {
+    border-width: 100px;
+}
+
+.dropup .btn {
+    content: "dropup btn";
+    .caret {
+        content: "dropup btn caret";
+    }
+}
+.dropup > .btn {
+    content: "dropup > btn";
+    > .caret {
+        content: "dropup > btn > caret";
+    }
+}
+.dropup + .btn {
+    content: "dropup + btn";
+    + .caret {
+        content: "dropup + btn + caret";
+    }
+}
+.dropup.btn {
+    content: "dropupbtn";
+    &.caret {
+        content: "dropupbtncaret";
+    }
+}
+
+.btn-group-lg > .btn {
+    @extend .btn-lg;
+}
+
+.extend {
+    .the-button {
+        @extend .btn;
+    }
+}

--- a/tests/inputs/nested_mixins.scss
+++ b/tests/inputs/nested_mixins.scss
@@ -1,0 +1,28 @@
+@mixin container() {
+    .container {
+        @content;
+    }
+}
+@mixin add-size($size) {
+    width: $size;
+}
+@function add($a, $b) {
+    @return $a + $b;
+}
+
+div {
+    @include container() {
+        $i: 10px;
+        @include container() {
+            width: $i;
+            max-width: add($i, 2px);
+        }
+        @include add-size($i);
+        .foo {
+            @include add-size($i);
+        }
+        .bar {
+            @include add-size(add($i, 2px));
+        }
+    }
+}

--- a/tests/outputs/extends.css
+++ b/tests/outputs/extends.css
@@ -138,3 +138,6 @@ body .to-extend, body .test {
     margin-left: 0; }
   .pagination-bullet.is-active {
     background-color: white; }
+
+.parent-nested-foo-include .in-nested-foo .child-nested-foo-include, .parent-nested-foo-include .in-nested-foo .beard + .mustache {
+  color: green; }

--- a/tests/outputs/extends_nesting.css
+++ b/tests/outputs/extends_nesting.css
@@ -1,0 +1,28 @@
+.btn, .extend .the-button {
+  padding: 1px; }
+
+.btn-lg, .btn-group-lg > .btn, .extend .btn-group-lg > .the-button {
+  font-size: 10px; }
+
+.dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .extend .btn-group-lg > .the-button .caret, .extend .dropup .btn-group-lg > .the-button .caret {
+  border-width: 100px; }
+
+.dropup .btn, .dropup .extend .the-button, .extend .dropup .the-button {
+  content: "dropup btn"; }
+  .dropup .btn .caret, .dropup .extend .the-button .caret, .extend .dropup .the-button .caret {
+    content: "dropup btn caret"; }
+
+.dropup > .btn, .extend .dropup > .the-button {
+  content: "dropup > btn"; }
+  .dropup > .btn > .caret, .extend .dropup > .the-button > .caret {
+    content: "dropup > btn > caret"; }
+
+.dropup + .btn, .extend .dropup + .the-button {
+  content: "dropup + btn"; }
+  .dropup + .btn + .caret, .extend .dropup + .the-button + .caret {
+    content: "dropup + btn + caret"; }
+
+.dropup.btn, .extend .the-button.dropup {
+  content: "dropupbtn"; }
+  .dropup.btn.caret, .extend .the-button.dropup.caret {
+    content: "dropupbtncaret"; }

--- a/tests/outputs/nested_mixins.css
+++ b/tests/outputs/nested_mixins.css
@@ -1,0 +1,9 @@
+div .container {
+  width: 10px; }
+  div .container .container {
+    width: 10px;
+    max-width: 12px; }
+  div .container .foo {
+    width: 10px; }
+  div .container .bar {
+    width: 12px; }

--- a/tests/outputs_numbered/extends.css
+++ b/tests/outputs_numbered/extends.css
@@ -215,3 +215,13 @@ body .to-extend, body .test {
   background-color: white; }
 /* line 303, inputs/extends.scss */
 /* line 304, inputs/extends.scss */
+
+/* line 315, inputs/extends.scss */
+
+/* line 310, inputs/extends.scss */
+
+/* line 317, inputs/extends.scss */
+
+.parent-nested-foo-include .in-nested-foo .child-nested-foo-include, .parent-nested-foo-include .in-nested-foo .beard + .mustache {
+  color: green; }
+/* line 323, inputs/extends.scss */

--- a/tests/outputs_numbered/extends_nesting.css
+++ b/tests/outputs_numbered/extends_nesting.css
@@ -1,0 +1,37 @@
+/* line 1, inputs/extends_nesting.scss */
+.btn, .extend .the-button {
+  padding: 1px; }
+/* line 4, inputs/extends_nesting.scss */
+.btn-lg, .btn-group-lg > .btn, .extend .btn-group-lg > .the-button {
+  font-size: 10px; }
+/* line 7, inputs/extends_nesting.scss */
+.dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .extend .btn-group-lg > .the-button .caret, .extend .dropup .btn-group-lg > .the-button .caret {
+  border-width: 100px; }
+/* line 11, inputs/extends_nesting.scss */
+.dropup .btn, .dropup .extend .the-button, .extend .dropup .the-button {
+  content: "dropup btn"; }
+/* line 13, inputs/extends_nesting.scss */
+.dropup .btn .caret, .dropup .extend .the-button .caret, .extend .dropup .the-button .caret {
+  content: "dropup btn caret"; }
+/* line 17, inputs/extends_nesting.scss */
+.dropup > .btn, .extend .dropup > .the-button {
+  content: "dropup > btn"; }
+/* line 19, inputs/extends_nesting.scss */
+.dropup > .btn > .caret, .extend .dropup > .the-button > .caret {
+  content: "dropup > btn > caret"; }
+/* line 23, inputs/extends_nesting.scss */
+.dropup + .btn, .extend .dropup + .the-button {
+  content: "dropup + btn"; }
+/* line 25, inputs/extends_nesting.scss */
+.dropup + .btn + .caret, .extend .dropup + .the-button + .caret {
+  content: "dropup + btn + caret"; }
+/* line 29, inputs/extends_nesting.scss */
+.dropup.btn, .extend .the-button.dropup {
+  content: "dropupbtn"; }
+/* line 31, inputs/extends_nesting.scss */
+.dropup.btn.caret, .extend .the-button.dropup.caret {
+  content: "dropupbtncaret"; }
+/* line 36, inputs/extends_nesting.scss */
+/* line 40, inputs/extends_nesting.scss */
+
+/* line 41, inputs/extends_nesting.scss */

--- a/tests/outputs_numbered/nested_mixins.css
+++ b/tests/outputs_numbered/nested_mixins.css
@@ -1,0 +1,14 @@
+/* line 13, inputs/nested_mixins.scss */
+/* line 2, inputs/nested_mixins.scss */
+  div .container {
+    width: 10px; }
+/* line 2, inputs/nested_mixins.scss */
+div .container .container {
+  width: 10px;
+  max-width: 12px; }
+/* line 21, inputs/nested_mixins.scss */
+div .container .foo {
+  width: 10px; }
+/* line 24, inputs/nested_mixins.scss */
+div .container .bar {
+  width: 12px; }


### PR DESCRIPTION
I noticed during work that the bit added to the test case was not compiled the same using `node-sass`. It may look strange that the build files are changed but I've confirmed that the output of `extends.css` matches 1 to 1 the compiled version of `extends.scss` using `node-sass`.

```
$ git log -1 --oneline && node-sass -v && vendor/bin/phpunit 
98ae18f Extend resolution was generating invalid selectors
node-sass	3.8.0	(Wrapper)	[JavaScript]
libsass  	3.3.6	(Sass Compiler)	[C/C++]
PHPUnit 3.7.38 by Sebastian Bergmann.

Configuration read from /home/fred/apps/scssphp/phpunit.xml.dist

.................S.............................................  63 / 349 ( 18%)
........................S...................................... 126 / 349 ( 36%)
............................................................... 189 / 349 ( 54%)
............................................................... 252 / 349 ( 72%)
............................................................... 315 / 349 ( 90%)
..................................

Time: 561 ms, Memory: 20.00MB

OK, but incomplete or skipped tests!
Tests: 349, Assertions: 77, Skipped: 2.
```

Side by side comparison: https://gist.github.com/FMCorz/0b0377c3a86e6ac2be558c5895266a5c/revisions?diff=split
