### PR TITLE
Let @content work when a block isn’t passed in.

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1723,7 +1723,9 @@ class Compiler
                          ?: $this->get(self::$namespaces['special'] . 'content', false, $this->env);
 
                 if (! $content) {
-                    $this->throwError('Expected @content inside of mixin');
+                    $content = new \stdClass();
+                    $content->scope = new \stdClass();
+                    $content->children = $this->storeEnv->parent->block->children;
                     break;
                 }
 

--- a/tests/inputs/content.scss
+++ b/tests/inputs/content.scss
@@ -116,3 +116,12 @@ A {
     display: none;
   }
 }
+
+@mixin empty_content() {
+  @content;
+}
+.test_empty_content {
+  display: inline;
+  font-weight: bold;
+  @include empty_content()
+}

--- a/tests/outputs/content.css
+++ b/tests/outputs/content.css
@@ -36,3 +36,7 @@ A {
 
 .test {
   display: none; }
+
+.test_empty_content {
+  display: inline;
+  font-weight: bold; }

--- a/tests/outputs_numbered/content.css
+++ b/tests/outputs_numbered/content.css
@@ -45,3 +45,7 @@ A {
 /* line 114, inputs/content.scss */
 .test {
   display: none; }
+/* line 123, inputs/content.scss */
+.test_empty_content {
+  display: inline;
+  font-weight: bold; }


### PR DESCRIPTION
Before the following scss would work fine with ruby sass, but throw an "Expected @content inside of mixin" exception in pscss.

````
@mixin border-radius($radius) {
   -webkit-border-radius: $radius;
     -moz-border-radius: $radius;
      -ms-border-radius: $radius;
          border-radius: $radius;
  @content;
}

a {
  background: red;
  padding: 10px;
  @include border-radius(10px);
}
```

This allows it to work.