### PR TITLE
added tests for most common frameworks using scss

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.5",
         "phpunit/phpunit": "~3.7",
-        "kherge/box": "~2.5"
+        "kherge/box": "~2.5",
+        "twbs/bootstrap": "4.0.0-alpha.4",
+        "zurb/foundation": "~6.2"
     },
     "bin": ["bin/pscss"],
     "archive": {

--- a/tests/FrameworkTest.php
+++ b/tests/FrameworkTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2015 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://leafo.github.io/scssphp
+ */
+
+namespace Leafo\ScssPhp\Tests;
+
+use Leafo\ScssPhp\Compiler;
+
+class FrameworkTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $frameworks = [
+        [
+            "frameworkVerion" => "twbs/bootstrap4.0.0-alpha.4",
+            "inputdirectory" => "../vendor/twbs/bootstrap/scss/",
+            "inputfiles" => "bootstrap.scss",
+        ],
+        [
+            "frameworkVerion" => "zurb/foundation6.2",
+            "inputdirectory" => "../vendor/zurb/foundation/scss/",
+            "inputfiles" => "foundation.scss",
+        ]
+    ];
+
+    private $saveDir;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->scss = new Compiler();
+        $this->saveDir = getcwd();
+
+        chdir(__DIR__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function tearDown()
+    {
+        chdir($this->saveDir);
+    }
+
+    /**
+     * @dataProvider frameworkProvider
+     */
+    public function testFramework($frameworkVerion, $inputdirectory, $inputfiles)
+    {
+        $this->scss->addImportPath($inputdirectory);
+
+        $input = file_get_contents($inputdirectory.$inputfiles);
+        
+        //Test if no exeption are raised for the given framwork
+        $e = null;
+        try {
+            $this->scss->compile($input, $inputfiles);
+        } catch (Exception $e) {
+            // test fail
+        }
+
+        $this->assertNull($e);
+    }
+
+    public function frameworkProvider(){
+        return self::$frameworks;
+    }
+}

--- a/tests/FrameworkTest.php
+++ b/tests/FrameworkTest.php
@@ -23,7 +23,7 @@ class FrameworkTest extends \PHPUnit_Framework_TestCase
         ],
         [
             "frameworkVerion" => "zurb/foundation6.2",
-            "inputdirectory" => "../vendor/zurb/foundation/scss/",
+            "inputdirectory" => "../vendor/zurb/foundation/assets/",
             "inputfiles" => "foundation.scss",
         ]
     ];


### PR DESCRIPTION
#449 & #446 make me think that it is a good quality indicator to know if scssphp is able to compile the scss from the most famous css/scss frameworks.

I added a test for : 
- bootstrap 4
  - test pass
- foundation 6
  - test fail : Undefined variable $i: line: 86
