### PR TITLE
Add $cacheDir for serveFrom

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -455,7 +455,7 @@ class Server
      *
      * @param string $path Root path
      */
-    public static function serveFrom($path)
+    public static function serveFrom($path, $cacheDir = null)
     {
         $server = new static($path);
         $server->serve();


### PR DESCRIPTION
I think it improve the usability of the script to allow Setup the cacheDir via the static serveFrom function.