### PR TITLE
Registered Functions return Null

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3580,7 +3580,7 @@ class Compiler
 
         $returnValue = call_user_func($f, $sorted, $kwargs);
 
-        if (! isset($returnValue)) {
+        if (!isset($returnValue) && !is_null($returnValue)) {
             return false;
         }
 


### PR DESCRIPTION
Any registered function that returns null shouldn't render line.