### PR TITLE
Fix incorrect permissions on creating cache directory

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -434,7 +434,7 @@ class Server
         $this->cacheDir = $cacheDir;
 
         if (! is_dir($this->cacheDir)) {
-            mkdir($this->cacheDir, 0755, true);
+            mkdir($this->cacheDir, 0777, true);
         }
 
         if (! isset($scss)) {


### PR DESCRIPTION
The previous permissions denied group/other write permissions for the cache directory, which can be problematic. Note that the default `umask` (`0755`) still yields the previous behaviour, so security-wise, nothing changes.

The previous behaviour was problematic for our use case: we use ACL's requiring the group writing bit set (thus using a suitable non-default `umask`), which did not work with the old code.