### PR TITLE
fixes #532 Substitute deprecated php function each()

### DIFF
--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -290,7 +290,7 @@ class Number extends Node implements \ArrayAccess
         }
 
         reset($units);
-        list($unit, ) = each($units);
+        $unit = key($units);
 
         return (string) $dimension . $unit;
     }


### PR DESCRIPTION
Function each() deprecated in PHP7.2