### PR TITLE
See #135: add inline sourceMaps support

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -29,6 +29,11 @@ class Block
     public $parent;
 
     /**
+     * @var string;
+     */
+    public $sourceName;
+
+    /**
      * @var integer
      */
     public $sourceIndex;

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -256,7 +256,7 @@ abstract class Formatter
                 $this->currentLine,
                 $this->currentColumn,
                 $this->currentBlock->sourceLine,
-                $this->currentBlock->sourceColumn,
+                $this->currentBlock->sourceColumn - 1, //columns from parser are off by one
                 $this->currentBlock->sourceName
             );
 

--- a/src/Formatter/Compressed.php
+++ b/src/Formatter/Compressed.php
@@ -53,10 +53,10 @@ class Compressed extends Formatter
             }
         }
 
-        echo $inner . implode($glue, $block->lines);
+        $this->write( $inner . implode($glue, $block->lines));
 
         if (! empty($block->children)) {
-            echo $this->break;
+            $this->write( $this->break);
         }
     }
 }

--- a/src/Formatter/Crunched.php
+++ b/src/Formatter/Crunched.php
@@ -51,10 +51,10 @@ class Crunched extends Formatter
             }
         }
 
-        echo $inner . implode($glue, $block->lines);
+        $this->write($inner . implode($glue, $block->lines));
 
         if (! empty($block->children)) {
-            echo $this->break;
+            $this->write($this->break);
         }
     }
 }

--- a/src/Formatter/Debug.php
+++ b/src/Formatter/Debug.php
@@ -52,13 +52,13 @@ class Debug extends Formatter
         $indent = $this->indentStr();
 
         if (empty($block->lines)) {
-            echo "{$indent}block->lines: []\n";
+            $this->write("{$indent}block->lines: []\n");
 
             return;
         }
 
         foreach ($block->lines as $index => $line) {
-            echo "{$indent}block->lines[{$index}]: $line\n";
+            $this->write( "{$indent}block->lines[{$index}]: $line\n");
         }
     }
 
@@ -70,13 +70,13 @@ class Debug extends Formatter
         $indent = $this->indentStr();
 
         if (empty($block->selectors)) {
-            echo "{$indent}block->selectors: []\n";
+            $this->write( "{$indent}block->selectors: []\n");
 
             return;
         }
 
         foreach ($block->selectors as $index => $selector) {
-            echo "{$indent}block->selectors[{$index}]: $selector\n";
+            $this->write( "{$indent}block->selectors[{$index}]: $selector\n");
         }
     }
 
@@ -88,7 +88,7 @@ class Debug extends Formatter
         $indent = $this->indentStr();
 
         if (empty($block->children)) {
-            echo "{$indent}block->children: []\n";
+            $this->write( "{$indent}block->children: []\n");
 
             return;
         }
@@ -109,8 +109,10 @@ class Debug extends Formatter
     {
         $indent = $this->indentStr();
 
-        echo "{$indent}block->type: {$block->type}\n" .
-             "{$indent}block->depth: {$block->depth}\n";
+        $this->write( "{$indent}block->type: {$block->type}\n" .
+             "{$indent}block->depth: {$block->depth}\n");
+
+        $this->currentBlock = $block;
 
         $this->blockSelectors($block);
         $this->blockLines($block);

--- a/src/Formatter/Expanded.php
+++ b/src/Formatter/Expanded.php
@@ -59,10 +59,10 @@ class Expanded extends Formatter
             }
         }
 
-        echo $inner . implode($glue, $block->lines);
+        $this->write($inner . implode($glue, $block->lines));
 
         if (empty($block->selectors) || ! empty($block->children)) {
-            echo $this->break;
+            $this->write($this->break);
         }
     }
 }

--- a/src/Formatter/Nested.php
+++ b/src/Formatter/Nested.php
@@ -12,7 +12,6 @@
 namespace Leafo\ScssPhp\Formatter;
 
 use Leafo\ScssPhp\Formatter;
-use Leafo\ScssPhp\Formatter\OutputBlock;
 
 /**
  * Nested formatter
@@ -66,10 +65,10 @@ class Nested extends Formatter
             }
         }
 
-        echo $inner . implode($glue, $block->lines);
+        $this->write( $inner . implode($glue, $block->lines));
 
         if (! empty($block->children)) {
-            echo $this->break;
+            $this->write( $this->break);
         }
     }
 
@@ -80,9 +79,9 @@ class Nested extends Formatter
     {
         $inner = $this->indentStr();
 
-        echo $inner
+        $this->write( $inner
             . implode($this->tagSeparator, $block->selectors)
-            . $this->open . $this->break;
+            . $this->open . $this->break);
     }
 
     /**
@@ -94,13 +93,13 @@ class Nested extends Formatter
             $this->block($child);
 
             if ($i < count($block->children) - 1) {
-                echo $this->break;
+                $this->write( $this->break);
 
                 if (isset($block->children[$i + 1])) {
                     $next = $block->children[$i + 1];
 
                     if ($next->depth === max($block->depth, 1) && $child->depth >= $next->depth) {
-                        echo $this->break;
+                        $this->write( $this->break);
                     }
                 }
             }
@@ -119,6 +118,9 @@ class Nested extends Formatter
         if (empty($block->lines) && empty($block->children)) {
             return;
         }
+
+        $this->currentBlock = $block;
+
 
         $this->depth = $block->depth;
 
@@ -139,11 +141,11 @@ class Nested extends Formatter
         if (! empty($block->selectors)) {
             $this->indentLevel--;
 
-            echo $this->close;
+            $this->write( $this->close);
         }
 
         if ($block->type === 'root') {
-            echo $this->break;
+            $this->write( $this->break);
         }
     }
 

--- a/src/Formatter/OutputBlock.php
+++ b/src/Formatter/OutputBlock.php
@@ -47,4 +47,19 @@ class OutputBlock
      * @var \Leafo\ScssPhp\Formatter\OutputBlock
      */
     public $parent;
+
+    /**
+     * @var string
+     */
+    public $sourceName;
+
+    /**
+     * @var int
+     */
+    public $sourceLine;
+
+    /**
+     * @var int
+     */
+    public $sourceColumn;
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -708,6 +708,7 @@ class Parser
         list($line, $column) = $this->getSourcePosition($pos);
 
         $b = new Block;
+        $b->sourceName = $this->sourceName;
         $b->sourceLine   = $line;
         $b->sourceColumn = $column;
         $b->sourceIndex  = $this->sourceIndex;

--- a/src/SourceMap/Base64VLQEncoder.php
+++ b/src/SourceMap/Base64VLQEncoder.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: nico
+ * Date: 08/11/17
+ * Time: 19:14
+ */
+
+namespace Leafo\ScssPhp\SourceMap;
+
+
+class Base64VLQEncoder {
+    /**
+     * Shift
+     *
+     * @var integer
+     */
+    private $shift = 5;
+    /**
+     * Mask
+     *
+     * @var integer
+     */
+    private $mask = 0x1F; // == (1 << shift) == 0b00011111
+    /**
+     * Continuation bit
+     *
+     * @var integer
+     */
+    private $continuationBit = 0x20; // == (mask - 1 ) == 0b00100000
+    /**
+     * Char to integer map
+     *
+     * @var array
+     */
+    private $charToIntMap = array(
+        'A' => 0, 'B' => 1, 'C' => 2, 'D' => 3, 'E' => 4, 'F' => 5, 'G' => 6,
+        'H' => 7,'I' => 8, 'J' => 9, 'K' => 10, 'L' => 11, 'M' => 12, 'N' => 13,
+        'O' => 14, 'P' => 15, 'Q' => 16, 'R' => 17, 'S' => 18, 'T' => 19, 'U' => 20,
+        'V' => 21, 'W' => 22, 'X' => 23, 'Y' => 24, 'Z' => 25, 'a' => 26, 'b' => 27,
+        'c' => 28, 'd' => 29, 'e' => 30, 'f' => 31, 'g' => 32, 'h' => 33, 'i' => 34,
+        'j' => 35, 'k' => 36, 'l' => 37, 'm' => 38, 'n' => 39, 'o' => 40, 'p' => 41,
+        'q' => 42, 'r' => 43, 's' => 44, 't' => 45, 'u' => 46, 'v' => 47, 'w' => 48,
+        'x' => 49, 'y' => 50, 'z' => 51, 0 => 52, 1 => 53, 2 => 54, 3 => 55, 4 => 56,
+        5 => 57,	6 => 58, 7 => 59, 8 => 60, 9 => 61, '+' => 62, '/' => 63,
+    );
+    /**
+     * Integer to char map
+     *
+     * @var array
+     */
+    private $intToCharMap = array(
+        0 => 'A', 1 => 'B', 2 => 'C', 3 => 'D', 4 => 'E', 5 => 'F', 6 => 'G',
+        7 => 'H', 8 => 'I', 9 => 'J', 10 => 'K', 11 => 'L', 12 => 'M', 13 => 'N',
+        14 => 'O', 15 => 'P', 16 => 'Q', 17 => 'R', 18 => 'S', 19 => 'T', 20 => 'U',
+        21 => 'V', 22 => 'W', 23 => 'X', 24 => 'Y', 25 => 'Z', 26 => 'a', 27 => 'b',
+        28 => 'c', 29 => 'd', 30 => 'e', 31 => 'f', 32 => 'g', 33 => 'h', 34 => 'i',
+        35 => 'j', 36 => 'k', 37 => 'l', 38 => 'm', 39 => 'n', 40 => 'o', 41 => 'p',
+        42 => 'q', 43 => 'r', 44 => 's', 45 => 't', 46 => 'u', 47 => 'v', 48 => 'w',
+        49 => 'x', 50 => 'y', 51 => 'z', 52 => '0', 53 => '1', 54 => '2', 55 => '3',
+        56 => '4', 57 => '5', 58 => '6', 59 => '7', 60 => '8', 61 => '9', 62 => '+',
+        63 => '/',
+    );
+    /**
+     * Constructor
+     */
+    public function __construct(){
+        // I leave it here for future reference
+        // foreach(str_split('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/') as $i => $char)
+        // {
+        //	 $this->charToIntMap[$char] = $i;
+        //	 $this->intToCharMap[$i] = $char;
+        // }
+    }
+    /**
+     * Convert from a two-complement value to a value where the sign bit is
+     * is placed in the least significant bit.	For example, as decimals:
+     *	 1 becomes 2 (10 binary), -1 becomes 3 (11 binary)
+     *	 2 becomes 4 (100 binary), -2 becomes 5 (101 binary)
+     * We generate the value for 32 bit machines, hence -2147483648 becomes 1, not 4294967297,
+     * even on a 64 bit machine.
+     * @param string $aValue
+     */
+    public function toVLQSigned($aValue){
+        return 0xffffffff & ($aValue < 0 ? ((-$aValue) << 1) + 1 : ($aValue << 1) + 0);
+    }
+    /**
+     * Convert to a two-complement value from a value where the sign bit is
+     * is placed in the least significant bit. For example, as decimals:
+     *	 2 (10 binary) becomes 1, 3 (11 binary) becomes -1
+     *	 4 (100 binary) becomes 2, 5 (101 binary) becomes -2
+     * We assume that the value was generated with a 32 bit machine in mind.
+     * Hence
+     *	 1 becomes -2147483648
+     * even on a 64 bit machine.
+     * @param integer $aValue
+     */
+    public function fromVLQSigned($aValue){
+        return $aValue & 1 ? $this->zeroFill(~$aValue + 2, 1) | (-1 - 0x7fffffff) : $this->zeroFill($aValue, 1);
+    }
+    /**
+     * Return the base 64 VLQ encoded value.
+     *
+     * @param string $aValue The value to encode
+     * @return string The encoded value
+     */
+    public function encode($aValue){
+        $encoded = '';
+        $vlq = $this->toVLQSigned($aValue);
+        do
+        {
+            $digit = $vlq & $this->mask;
+            $vlq = $this->zeroFill($vlq, $this->shift);
+            if($vlq > 0){
+                $digit |= $this->continuationBit;
+            }
+            $encoded .= $this->base64Encode($digit);
+        } while($vlq > 0);
+        return $encoded;
+    }
+    /**
+     * Return the value decoded from base 64 VLQ.
+     *
+     * @param string $encoded The encoded value to decode
+     * @return integer The decoded value
+     */
+    public function decode($encoded){
+        $vlq = 0;
+        $i = 0;
+        do
+        {
+            $digit = $this->base64Decode($encoded[$i]);
+            $vlq |= ($digit & $this->mask) << ($i * $this->shift);
+            $i++;
+        } while($digit & $this->continuationBit);
+        return $this->fromVLQSigned($vlq);
+    }
+    /**
+     * Right shift with zero fill.
+     *
+     * @param integer $a number to shift
+     * @param integer $b number of bits to shift
+     * @return integer
+     */
+    public function zeroFill($a, $b){
+        return ($a >= 0) ? ($a >> $b) : ($a >> $b) & (PHP_INT_MAX >> ($b - 1));
+    }
+    /**
+     * Encode single 6-bit digit as base64.
+     *
+     * @param integer $number
+     * @return string
+     * @throws Exception If the number is invalid
+     */
+    public function base64Encode($number){
+        if($number < 0 || $number > 63){
+            throw new Exception(sprintf('Invalid number "%s" given. Must be between 0 and 63.', $number));
+        }
+        return $this->intToCharMap[$number];
+    }
+    /**
+     * Decode single 6-bit digit from base64
+     *
+     * @param string $char
+     * @return number
+     * @throws Exception If the number is invalid
+     */
+    public function base64Decode($char){
+        if(!array_key_exists($char, $this->charToIntMap)){
+            throw new Exception(sprintf('Invalid base 64 digit "%s" given.', $char));
+        }
+        return $this->charToIntMap[$char];
+    }
+}

--- a/src/SourceMap/SourceMapGenerator.php
+++ b/src/SourceMap/SourceMapGenerator.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: nico
+ * Date: 08/11/17
+ * Time: 19:16
+ */
+
+namespace Leafo\ScssPhp\SourceMap;
+
+class SourceMapGenerator {
+    /**
+     * What version of source map does the generator generate?
+     */
+    const VERSION = 3;
+    /**
+     * Array of default options
+     *
+     * @var array
+     */
+    protected $defaultOptions = array(
+        // an optional source root, useful for relocating source files
+        // on a server or removing repeated values in the 'sources' entry.
+        // This value is prepended to the individual entries in the 'source' field.
+        'sourceRoot' => '',
+        // an optional name of the generated code that this source map is associated with.
+        'sourceMapFilename' => null,
+        // url of the map
+        'sourceMapURL' => null,
+        // absolute path to a file to write the map to
+        'sourceMapWriteTo' => null,
+        // output source contents?
+        'outputSourceFiles' => false,
+        // base path for filename normalization
+        'sourceMapRootpath' => '',
+        // base path for filename normalization
+        'sourceMapBasepath' => ''
+    );
+
+    /**
+     * The base64 VLQ encoder
+     *
+     * @var Base64VLQEncoder
+     */
+    protected $encoder;
+    /**
+     * Array of mappings
+     *
+     * @var array
+     */
+    protected $mappings = array();
+
+    /**
+     * Array of contents map
+     *
+     * @var array
+     */
+    protected $contentsMap = array();
+    /**
+     * File to content map
+     *
+     * @var array
+     */
+    protected $sources = array();
+    protected $source_keys = array();
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(array $options = []) {
+        $this->options = array_merge($this->defaultOptions, $options);
+        $this->encoder = new Base64VLQEncoder();
+    }
+
+    /**
+     * Adds a mapping
+     *
+     * @param integer $generatedLine The line number in generated file
+     * @param integer $generatedColumn The column number in generated file
+     * @param integer $originalLine The line number in original file
+     * @param integer $originalColumn The column number in original file
+     * @param string $sourceFile The original source file
+     */
+    public function addMapping($generatedLine, $generatedColumn, $originalLine, $originalColumn, $sourceFile) {
+        $this->mappings[] = array(
+            'generated_line' => $generatedLine,
+            'generated_column' => $generatedColumn,
+            'original_line' => $originalLine,
+            'original_column' => $originalColumn,
+            'source_file' => $sourceFile
+        );
+
+        $this->sources[$sourceFile] = $sourceFile;
+    }
+
+    /**
+     * Generates the JSON source map
+     *
+     * @return string
+     * @see https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#
+     */
+    public function generateJson() {
+        $sourceMap = array();
+        $mappings = $this->generateMappings();
+        // File version (always the first entry in the object) and must be a positive integer.
+        $sourceMap['version'] = self::VERSION;
+        // An optional name of the generated code that this source map is associated with.
+        $file = $this->options['sourceMapFilename'];
+        if($file) {
+            $sourceMap['file'] = $file;
+        }
+        // An optional source root, useful for relocating source files on a server or removing repeated values in the 'sources' entry.	This value is prepended to the individual entries in the 'source' field.
+        $root = $this->options['sourceRoot'];
+        if($root) {
+            $sourceMap['sourceRoot'] = $root;
+        }
+        // A list of original sources used by the 'mappings' entry.
+        $sourceMap['sources'] = array();
+        foreach($this->sources as $source_uri => $source_filename) {
+            $sourceMap['sources'][] = $this->normalizeFilename($source_filename);
+        }
+        // A list of symbol names used by the 'mappings' entry.
+        $sourceMap['names'] = array();
+        // A string with the encoded mapping data.
+        $sourceMap['mappings'] = $mappings;
+        if($this->options['outputSourceFiles']) {
+            // An optional list of source content, useful when the 'source' can't be hosted.
+            // The contents are listed in the same order as the sources above.
+            // 'null' may be used if some original sources should be retrieved by name.
+            $sourceMap['sourcesContent'] = $this->getSourcesContent();
+        }
+        // less.js compat fixes
+        if(count($sourceMap['sources']) && empty($sourceMap['sourceRoot'])) {
+            unset($sourceMap['sourceRoot']);
+        }
+        return json_encode($sourceMap);
+    }
+
+    /**
+     * Returns the sources contents
+     *
+     * @return array|null
+     */
+    protected function getSourcesContent() {
+        if(empty($this->sources)) {
+            return null;
+        }
+        $content = array();
+        foreach($this->sources as $sourceFile) {
+            $content[] = file_get_contents($sourceFile);
+        }
+        return $content;
+    }
+
+    /**
+     * Generates the mappings string
+     *
+     * @return string
+     */
+    public function generateMappings() {
+        if(!count($this->mappings)) {
+            return '';
+        }
+        $this->source_keys = array_flip(array_keys($this->sources));
+        // group mappings by generated line number.
+        $groupedMap = $groupedMapEncoded = array();
+        foreach($this->mappings as $m) {
+            $groupedMap[$m['generated_line']][] = $m;
+        }
+        ksort($groupedMap);
+        $lastGeneratedLine = $lastOriginalIndex = $lastOriginalLine = $lastOriginalColumn = 0;
+        foreach($groupedMap as $lineNumber => $line_map) {
+            while(++$lastGeneratedLine < $lineNumber) {
+                $groupedMapEncoded[] = ';';
+            }
+            $lineMapEncoded = array();
+            $lastGeneratedColumn = 0;
+            foreach($line_map as $m) {
+                $mapEncoded = $this->encoder->encode($m['generated_column'] - $lastGeneratedColumn);
+                $lastGeneratedColumn = $m['generated_column'];
+                // find the index
+                if($m['source_file']) {
+                    $index = $this->findFileIndex($m['source_file']);
+                    if($index !== false) {
+                        $mapEncoded .= $this->encoder->encode($index - $lastOriginalIndex);
+                        $lastOriginalIndex = $index;
+                        // lines are stored 0-based in SourceMap spec version 3
+                        $mapEncoded .= $this->encoder->encode($m['original_line'] - 1 - $lastOriginalLine);
+                        $lastOriginalLine = $m['original_line'] - 1;
+                        $mapEncoded .= $this->encoder->encode($m['original_column'] - $lastOriginalColumn);
+                        $lastOriginalColumn = $m['original_column'];
+                    }
+                }
+                $lineMapEncoded[] = $mapEncoded;
+            }
+            $groupedMapEncoded[] = implode(',', $lineMapEncoded) . ';';
+        }
+        return rtrim(implode($groupedMapEncoded), ';');
+    }
+
+    /**
+     * Finds the index for the filename
+     *
+     * @param string $filename
+     * @return integer|false
+     */
+    protected function findFileIndex($filename) {
+        return $this->source_keys[$filename];
+    }
+
+    protected function normalizeFilename($filename) {
+        $filename = $this->fixWindowsPath($filename);
+        $rootpath = $this->options['sourceMapRootpath'];
+        $basePath = $this->options['sourceMapBasepath'];
+        // "Trim" the 'sourceMapBasepath' from the output filename.
+        if(strpos($filename, $basePath) === 0) {
+            $filename = substr($filename, strlen($basePath));
+        }
+        // Remove extra leading path separators.
+        if(strpos($filename, '\\') === 0 || strpos($filename, '/') === 0) {
+            $filename = substr($filename, 1);
+        }
+        return $rootpath . $filename;
+    }
+
+    /**
+     * fix windows paths
+     * @param  string $path
+     * @param bool $addEndSlash
+     * @return string
+     */
+    public function fixWindowsPath($path, $addEndSlash = false) {
+        $slash = ($addEndSlash) ? '/' : '';
+        if(!empty($path)) {
+            $path = str_replace('\\', '/', $path);
+            $path = rtrim($path, '/') . $slash;
+        }
+        return $path;
+    }
+}


### PR DESCRIPTION
 * Add setSourceMap() and setSourceMapOptions() methods.
 * Modify Parser, InputBlock and and Block to keep track of the original source file, line and and column.
 * Add SourceMapGenerator, hugely copied from oyekorge/less.php
 * Modify formatters to keep track of the current position, and to call SourceMapGenerator::addMapping when needed.
 * add sourceMap inlining to Compiler