### PR TITLE
Adds file based source maps in addition to inline source maps; adds cachedCompile() to Server

### DIFF
--- a/example/Server.php
+++ b/example/Server.php
@@ -417,6 +417,69 @@ class Server
     }
 
     /**
+   	 * Execute scssphp on a .scss file or a scssphp cache structure
+   	 *
+   	 * The scssphp cache structure contains information about a specific
+   	 * scss file having been parsed. It can be used as a hint for future
+   	 * calls to determine whether or not a rebuild is required.
+   	 *
+   	 * The cache structure contains two important keys that may be used
+   	 * externally:
+   	 *
+   	 * compiled: The final compiled CSS
+   	 * updated: The time (in seconds) the CSS was last compiled
+   	 *
+   	 * The cache structure is a plain-ol' PHP associative array and can
+   	 * be serialized and unserialized without a hitch.
+   	 *
+   	 * @param mixed $in Input
+   	 * @param bool $force Force rebuild?
+   	 * @return array scssphp cache structure
+   	 */
+   	public function cachedCompile($in, $force = false) {
+   		// assume no root
+   		$root = null;
+
+   		if (is_string($in)) {
+   			$root = $in;
+   		} elseif (is_array($in) and isset($in['root'])) {
+   			if ($force or ! isset($in['files'])) {
+   				// If we are forcing a recompile or if for some reason the
+   				// structure does not contain any file information we should
+   				// specify the root to trigger a rebuild.
+   				$root = $in['root'];
+   			} elseif (isset($in['files']) and is_array($in['files'])) {
+   				foreach ($in['files'] as $fname => $ftime ) {
+   					if (!file_exists($fname) or filemtime($fname) > $ftime) {
+   						// One of the files we knew about previously has changed
+   						// so we should look at our incoming root again.
+   						$root = $in['root'];
+   						break;
+   					}
+   				}
+   			}
+   		} else {
+   			// TODO: Throw an exception? We got neither a string nor something
+   			// that looks like a compatible lessphp cache structure.
+   			return null;
+   		}
+
+   		if ($root !== null) {
+   			// If we have a root value which means we should rebuild.
+   			$out = array();
+   			$out['root'] = $root;
+   			$out['compiled'] = $this->compileFile($root);
+   			$out['files'] = $this->scss->getParsedFiles();
+   			$out['updated'] = time();
+   			return $out;
+   		} else {
+   			// No changes, pass back the structure
+   			// we were given initially.
+   			return $in;
+   		}
+   	}
+
+    /**
      * Constructor
      *
      * @param string                       $dir      Root directory to .scss files

--- a/scss.inc.php
+++ b/scss.inc.php
@@ -11,6 +11,7 @@ if (! class_exists('Leafo\ScssPhp\Version', false)) {
     include_once __DIR__ . '/src/Compiler/Environment.php';
     include_once __DIR__ . '/src/Exception/CompilerException.php';
     include_once __DIR__ . '/src/Exception/ParserException.php';
+    include_once __DIR__ . '/src/Exception/RangeException.php';  //exp
     include_once __DIR__ . '/src/Exception/ServerException.php';
     include_once __DIR__ . '/src/Formatter.php';
     include_once __DIR__ . '/src/Formatter/Compact.php';
@@ -23,6 +24,9 @@ if (! class_exists('Leafo\ScssPhp\Version', false)) {
     include_once __DIR__ . '/src/Node.php';
     include_once __DIR__ . '/src/Node/Number.php';
     include_once __DIR__ . '/src/Parser.php';
+//    include_once __DIR__ . '/src/example/Server.php';
+    include_once __DIR__ . '/src/SourceMap/Base64VLQEncoder.php';
+    include_once __DIR__ . '/src/SourceMap/SourceMapGenerator.php';
     include_once __DIR__ . '/src/Type.php';
     include_once __DIR__ . '/src/Util.php';
     include_once __DIR__ . '/src/Version.php';

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -67,6 +67,7 @@ class Compiler
 
     const SOURCE_MAP_NONE = 0;
     const SOURCE_MAP_INLINE = 1;
+    const SOURCE_MAP_FILE = 2;
 
     /**
      * @var array
@@ -205,12 +206,14 @@ class Compiler
             $sourceMapGenerator = new SourceMapGenerator($this->sourceMapOptions);
         }
         $out = $this->formatter->format($this->scope, $sourceMapGenerator);
-        if($this->sourceMap &&  $this->sourceMap !== self::SOURCE_MAP_NONE) {
+        if(!empty($out) && $this->sourceMap &&  $this->sourceMap !== self::SOURCE_MAP_NONE) {
             $sourceMap = $sourceMapGenerator->generateJson();
 
             $sourceMapUrl = null;
             if($this->sourceMap == self::SOURCE_MAP_INLINE) {
                 $sourceMapUrl = sprintf('data:application/json,%s', self::encodeURIComponent($sourceMap));
+            } elseif ($this->sourceMap == self::SOURCE_MAP_FILE) {
+                $sourceMapUrl = $sourceMapGenerator->saveMap($sourceMap);
             }
 
             $out .= sprintf('/*# sourceMappingURL=%s */', $sourceMapUrl);

--- a/src/SourceMap/SourceMapGenerator.php
+++ b/src/SourceMap/SourceMapGenerator.php
@@ -8,6 +8,8 @@
 
 namespace Leafo\ScssPhp\SourceMap;
 
+use Leafo\ScssPhp\Exception\CompilerException;
+
 class SourceMapGenerator {
     /**
      * What version of source map does the generator generate?
@@ -93,6 +95,28 @@ class SourceMapGenerator {
 
         $this->sources[$sourceFile] = $sourceFile;
     }
+
+    /**
+   	 * Saves the source map to a file
+   	 *
+   	 * @param string $file The absolute path to a file
+   	 * @param string $content The content to write
+   	 * @throws Exception If the file could not be saved
+   	 */
+   	public function saveMap($content){
+   	    $file = $this->options['sourceMapWriteTo'];
+   		$dir = dirname($file);
+   		// directory does not exist
+   		if( !is_dir($dir) ){
+   			// FIXME: create the dir automatically?
+   			throw new CompilerException(sprintf('The directory "%s" does not exist. Cannot save the source map.', $dir));
+   		}
+   		// FIXME: proper saving, with dir write check!
+   		if(file_put_contents($file, $content) === false){
+   			throw new CompilerException(sprintf('Cannot save the source map to "%s"', $file));
+   		}
+   		return $this->options['sourceMapURL'];
+   	}
 
     /**
      * Generates the JSON source map


### PR DESCRIPTION
Taking code from less.php, this allows for SOURCE_MAP_FILE sourceMap type to output file based source maps instead of only inline source maps being included in the css file output. Also includes a modified version of the cachedCompile() method into the Server example.