### PR TITLE
Actually merge maps instead of just concatenating

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4985,7 +4985,17 @@ class Compiler
         $map1 = $this->assertMap($args[0]);
         $map2 = $this->assertMap($args[1]);
 
-        return [Type::T_MAP, array_merge($map1[1], $map2[1]), array_merge($map1[2], $map2[2])];
+        foreach ($map2[1] as $i2 => $key2) {
+            foreach ($map1[1] as $i1 => $key1) {
+                if ($this->compileStringContent($this->coerceString($key1)) === $this->compileStringContent($this->coerceString($key2))) {
+                    $map1[2][$i1] = $map2[2][$i2];
+                    continue 2;
+                }
+            }
+            $map1[1][] = $map2[1][$i2];
+            $map1[2][] = $map2[2][$i2];
+        }
+        return $map1;
     }
 
     protected static $libKeywords = ['args'];

--- a/tests/inputs/map.scss
+++ b/tests/inputs/map.scss
@@ -25,9 +25,10 @@ div {
     bar: nth(nth($map, 1), 1);
 }
 
-$color: ("black" : #000000);
+$color: ("black" : #000000, "grey" : #777777);
+$color2: ("grey" : #888888, "white" : #ffffff);
 
-@each $color_name, $color_value in $color {
+@each $color_name, $color_value in map_merge( $color, $color2 ) {
     .#{$color_name} {
         background-color: $color_value !important;
     }

--- a/tests/outputs/map.css
+++ b/tests/outputs/map.css
@@ -12,6 +12,10 @@ div {
   bar: color; }
   .black {
     background-color: #000 !important; }
+  .grey {
+    background-color: #888 !important; }
+  .white {
+    background-color: #fff !important; }
 
 div {
   a: 1;

--- a/tests/outputs_numbered/map.css
+++ b/tests/outputs_numbered/map.css
@@ -11,10 +11,16 @@ div {
 div {
   foo: color black;
   bar: color; }
-/* line 31, inputs/map.scss */
+/* line 32, inputs/map.scss */
 .black {
   background-color: #000 !important; }
-/* line 52, inputs/map.scss */
+/* line 32, inputs/map.scss */
+.grey {
+  background-color: #888 !important; }
+/* line 32, inputs/map.scss */
+.white {
+  background-color: #fff !important; }
+/* line 53, inputs/map.scss */
 div {
   a: 1;
   b: 2;


### PR DESCRIPTION
`libMapMerge` used to just concatenate maps, i.e. two maps containing the same key would be merged into one map containing that key twice. The duplicate key did not appear in the css output when the map was used directly in then scss, but it was used by `each` loops.

This patch fixes it so that the resulting map contains that key only once.