### PR TITLE
fix doc for addImportPath, should also accept callable as input

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3308,7 +3308,7 @@ class Compiler
      *
      * @api
      *
-     * @param string $path
+     * @param string|callable $path
      */
     public function addImportPath($path)
     {


### PR DESCRIPTION
Hi,

First of all, thank you for this incredible package !

I've been working on PHP Code Quality tool called phpstan, and here is a small enhancement inside comments of the `Compiler::addImportPath` function which should also allow `callable` type in input.

Unless, you get an error when launching phpstan : 
```
------ ---------------------------------------------------------------------- 
  Line   src/Services/WhiteLabelService.php                                    
 ------ ---------------------------------------------------------------------- 
  18     Parameter #1 $path of method Leafo\ScssPhp\Compiler::addImportPath()  
         expects string, Closure given.                                        
 ------ ----------------------------------------------------------------------
```