### PR TITLE
Bug fix error thrown from strpos if needle (basePath) is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .sass-cache
 scss_cache
 composer.lock

--- a/src/SourceMap/SourceMapGenerator.php
+++ b/src/SourceMap/SourceMapGenerator.php
@@ -303,7 +303,7 @@ class SourceMapGenerator
         $basePath = $this->options['sourceMapBasepath'];
 
         // "Trim" the 'sourceMapBasepath' from the output filename.
-        if (strpos($filename, $basePath) === 0) {
+        if (strlen($basePath) && strpos($filename, $basePath) === 0) {
             $filename = substr($filename, strlen($basePath));
         }
 


### PR DESCRIPTION
If sourceMapBasepath is empty the function strpos() throws a needle empty error. This is a very small bug fix which checks the length of the sourceMapBasepath before strpos() is called.