### PR TITLE
 Fix rooted SCSS URIs normalised incorrectly with double slashes

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3481,9 +3481,12 @@ class Compiler
             if (is_string($dir)) {
                 // check urls for normal import paths
                 foreach ($urls as $full) {
-                    $full = $dir
-                        . (! empty($dir) && substr($dir, -1) !== '/' ? '/' : '')
-                        . $full;
+                    $separator = (
+                        !empty($dir) &&
+                        substr($dir, -1) !== '/' &&
+                        substr($full, 0, 1) !== '/'
+                    ) ? '/' : '';
+                    $full = $dir . $separator . $full;
 
                     if ($this->fileExists($file = $full . '.scss') ||
                         ($hasExtension && $this->fileExists($file = $full))

--- a/src/SourceMap/SourceMapGenerator.php
+++ b/src/SourceMap/SourceMapGenerator.php
@@ -202,7 +202,7 @@ class SourceMapGenerator
             unset($sourceMap['sourceRoot']);
         }
 
-        return json_encode($sourceMap);
+        return json_encode($sourceMap, JSON_UNESCAPED_SLASHES);
     }
 
     /**


### PR DESCRIPTION
Adding a rooted URI (starting with '/') as a the map filename can result in a double slash within the resulting `SourceMapGenerator` full path calculations which then results in unstable maps. I have added an additional check to avoid double slashes.

For example:

```php
$scss->setSourceMap(Compiler::SOURCE_MAP_INLINE);
$scss->setSourceMapOptions([
    'sourceMapFilename' => '/example/path/to/css.scss',
    'sourceMapBasepath' => '/var/www/vhosts/path-to-host',
    'sourceRoot' => '/'
]);
$source = $scss->compile($this->source, '/example/path/to/css.scss');
```

Can result in a full path of  `/var/www/vhosts/path-to-host//example/path/to/css.scss`. 
Since all of our URIs are rooted in this way I have added an additional check to avoid double slashes. Hopefully this might help someone else with similar code requirements and should not break the existing functionality. 

The other commit was to avoid slashes in JSON encoded URIs. But this is just a preference of mine. 