### PR TITLE
Add interpolation support selector.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,17 @@
         "psr-4": { "Leafo\\ScssPhp\\": "src/" }
     },
     "autoload-dev": {
-        "psr-4": { "Leafo\\ScssPhp\\Test\\": "tests/" }
+        "psr-4": { "Leafo\\ScssPhp\\Test\\": "tests/" },
+        "classmap": [
+            "src/"
+        ]
     },
     "require": {
         "php": ">=5.4.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.5",
-        "phpunit/phpunit": "~4.6"
+        "phpunit/phpunit": "^7"
     },
     "bin": ["bin/pscss"],
     "archive": {

--- a/src/Block.php
+++ b/src/Block.php
@@ -62,4 +62,12 @@ class Block
      * @var array
      */
     public $children;
+    /**
+     * @var \Leafo\ScssPhp\Block
+     */
+    public $atrootParent;
+    /**
+     * @var array
+     */
+    public $atrootParentSelectors;
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -715,6 +715,7 @@ class Parser
         $b->selectors    = $selectors;
         $b->comments     = [];
         $b->parent       = $this->env;
+        $b->atrootParent = $this->env;
 
         if (! $this->env) {
             $b->children = [];
@@ -762,7 +763,9 @@ class Parser
         if (empty($block->parent)) {
             $this->throwParseError('unexpected }');
         }
-
+//        if ($block->type == Type::T_AT_ROOT || $block->type == Type::T_MIXIN || $block->type == Type::T_INCLUDE) {
+//            $block->atrootParent = $block->parent;
+//        }
         $this->env = $block->parent;
         unset($block->parent);
 
@@ -1897,18 +1900,35 @@ class Parser
     {
         $oldWhite = $this->eatWhiteDefault;
         $this->eatWhiteDefault = true;
+        $selector = false;
 
         $s = $this->seek();
 
         if ($this->literal('#{') && $this->valueList($value) && $this->literal('}', false)) {
+
             if ($lookWhite) {
                 $left = preg_match('/\s/', $this->buffer[$s - 1]) ? ' ' : '';
-                $right = preg_match('/\s/', $this->buffer[$this->count]) ? ' ': '';
+                $right = preg_match('/\s/', $this->buffer[$this->count]) ? ' ' : '';
             } else {
                 $left = $right = false;
             }
-
             $out = [Type::T_INTERPOLATE, $value, $left, $right];
+
+            $this->eatWhiteDefault = $oldWhite;
+
+            if ($this->eatWhiteDefault) {
+                $this->whitespace();
+            }
+
+            return true;
+        }
+
+        $this->seek($s);
+
+        if ($this->literal('#{') && $selector = $this->selectorSingle($sel) && $this->literal('}', false)) {
+
+            $out = $sel[0];
+
             $this->eatWhiteDefault = $oldWhite;
 
             if ($this->eatWhiteDefault) {
@@ -2095,6 +2115,11 @@ class Parser
                 $parts[] = Compiler::$selfSelector;
                 continue;
             }
+            // self
+//            if ($this->literal('#{&}', true)) {
+//                $parts[] = Compiler::$selfSelector;
+//                continue;
+//            }
 
             if ($this->literal('.', false)) {
                 $parts[] = '.';

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -18,7 +18,7 @@ use Leafo\ScssPhp\Compiler;
  *
  * @author Leaf Corcoran <leafot@gmail.com>
  */
-class ApiTest extends \PHPUnit_Framework_TestCase
+class ApiTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Base64VLQTest.php
+++ b/tests/Base64VLQTest.php
@@ -18,7 +18,7 @@ use Leafo\ScssPhp\SourceMap\Base64VLQ;
  *
  * @author Anthon Pang <anthon.pang@gmail.com>
  */
-class Base64VLQTest extends \PHPUnit_Framework_TestCase
+class Base64VLQTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test encode

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -18,7 +18,7 @@ use Leafo\ScssPhp\Compiler;
  *
  * @author Leaf Corcoran <leafot@gmail.com>
  */
-class ExceptionTest extends \PHPUnit_Framework_TestCase
+class ExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/FailingTest.php
+++ b/tests/FailingTest.php
@@ -22,7 +22,7 @@ use Leafo\ScssPhp\Compiler;
  *
  * @author Anthon Pang <anthon.pang@gmail.com>
  */
-class FailingTest extends \PHPUnit_Framework_TestCase
+class FailingTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -29,7 +29,7 @@ function _quote($str)
  *
  * @author Leaf Corcoran <leafot@gmail.com>
  */
-class InputTest extends \PHPUnit_Framework_TestCase
+class InputTest extends \PHPUnit\Framework\TestCase
 {
     protected static $inputDir = 'inputs';
     protected static $outputDir = 'outputs';

--- a/tests/ScssTest.php
+++ b/tests/ScssTest.php
@@ -18,7 +18,7 @@ use Leafo\ScssPhp\Compiler;
  *
  * @author Leaf Corcoran <leafot@gmail.com>
  */
-class ScssTest extends \PHPUnit_Framework_TestCase
+class ScssTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @param string $name

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -20,7 +20,7 @@ use Leafo\ScssPhp\Server;
  *
  * @author Zimzat <zimzat@zimzat.com>
  */
-class ServerTest extends \PHPUnit_Framework_TestCase
+class ServerTest extends \PHPUnit\Framework\TestCase
 {
     public function testCheckedCachedCompile()
     {


### PR DESCRIPTION
> Update phpunit 7.
> Fix compile code like:
> @at-root a#{&} {
> }


@kingyond mentions this fork in https://github.com/leafo/scssphp/issues/616#issuecomment-455481858 but for some reason hasnt opend a PR. I think there's a couple issues with the fix, but I figure a PR will at least better organize discussion about it. @mind-bending-forks also notes that they believe this fixes #616 as well https://github.com/leafo/scssphp/issues/616#issuecomment-464900930