### PR TITLE
Avoid infinitely duplicating parts when extending selector

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -463,7 +463,12 @@ class Compiler
                     $tempReplacement = $k > 0 ? array_slice($new, $k) : $new;
 
                     for ($l = count($tempReplacement) - 1; $l >= 0; $l--) {
-                        $slice = $tempReplacement[$l];
+                        $slice = [];
+                        foreach ($tempReplacement[$l] as $chunk) {
+                            if (!in_array($chunk, $slice)) {
+                                $slice[] = $chunk;
+                            }
+                        }
                         array_unshift($replacement, $slice);
 
                         if (! $this->isImmediateRelationshipCombinator(end($slice))) {

--- a/tests/inputs/extending_compound_selector.scss
+++ b/tests/inputs/extending_compound_selector.scss
@@ -1,0 +1,19 @@
+.foo {
+  &:after {
+    color: red;
+  }
+  &:hover:after {
+    color: blue;
+  }
+}
+
+.bar {
+  @extend .foo;
+  &:before {
+    @extend .bar:after;
+  }
+}
+
+.baz.bar:before {
+  @extend .bar:before;
+}

--- a/tests/outputs/extending_compound_selector.css
+++ b/tests/outputs/extending_compound_selector.css
@@ -1,0 +1,4 @@
+.foo:after, .bar:after, .bar:before, .baz.bar:before {
+  color: red; }
+  .foo:hover:after, .bar:hover:after, .bar:before:hover, .baz.bar:before:hover {
+    color: blue; }

--- a/tests/outputs_numbered/extending_compound_selector.css
+++ b/tests/outputs_numbered/extending_compound_selector.css
@@ -1,0 +1,11 @@
+/* line 1, inputs/extending_compound_selector.scss */
+/* line 2, inputs/extending_compound_selector.scss */
+  .foo:after, .bar:after, .bar:before, .baz.bar:before {
+    color: red; }
+/* line 5, inputs/extending_compound_selector.scss */
+.foo:hover:after, .bar:hover:after, .bar:before:hover, .baz.bar:before:hover {
+  color: blue; }
+/* line 10, inputs/extending_compound_selector.scss */
+/* line 12, inputs/extending_compound_selector.scss */
+
+/* line 17, inputs/extending_compound_selector.scss */


### PR DESCRIPTION
Fix for issue https://github.com/leafo/scssphp/issues/634

Compiler was duplicating selectors, resulting in ".foo.bar.bar.bar.bar" that ended up failing at comparison, so compiler assumed it was new selector. Whole thing ended up in infinite loop.

Added code that prevents duplicates and a test case.

Output matches Ruby version, except that Ruby additionally shows a deprecation notice: 
```
DEPRECATION WARNING on line 18 of test.scss:
Extending a compound selector, .bar:before, is deprecated and will not be supported in a future release.
Consider "@extend .bar, :before" instead.
See http://bit.ly/ExtendCompound for details.
```