### PR TITLE
Change private properties to protected in compiler

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -145,18 +145,18 @@ class Compiler
     protected $charsetSeen;
     protected $sourceNames;
 
-    private $indentLevel;
-    private $commentsSeen;
-    private $extends;
-    private $extendsMap;
-    private $parsedFiles;
-    private $parser;
-    private $sourceIndex;
-    private $sourceLine;
-    private $sourceColumn;
-    private $stderr;
-    private $shouldEvaluate;
-    private $ignoreErrors;
+    protected $indentLevel;
+    protected $commentsSeen;
+    protected $extends;
+    protected $extendsMap;
+    protected $parsedFiles;
+    protected $parser;
+    protected $sourceIndex;
+    protected $sourceLine;
+    protected $sourceColumn;
+    protected $stderr;
+    protected $shouldEvaluate;
+    protected $ignoreErrors;
 
     /**
      * Constructor
@@ -817,7 +817,7 @@ class Compiler
      *
      * @return array
      */
-    private function spliceTree($envs, Block $block, $without)
+    protected function spliceTree($envs, Block $block, $without)
     {
         $newBlock = null;
 
@@ -894,7 +894,7 @@ class Compiler
      *
      * @return integer
      */
-    private function compileWith($with)
+    protected function compileWith($with)
     {
         static $mapping = [
             'rule'     => self::WITH_RULE,
@@ -945,7 +945,7 @@ class Compiler
      *
      * @return \Leafo\ScssPhp\Compiler\Environment
      */
-    private function filterWithout($envs, $without)
+    protected function filterWithout($envs, $without)
     {
         $filtered = [];
 
@@ -968,7 +968,7 @@ class Compiler
      *
      * @return boolean
      */
-    private function isWithout($without, Block $block)
+    protected function isWithout($without, Block $block)
     {
         if ((($without & static::WITH_RULE) && isset($block->selectors)) ||
             (($without & static::WITH_MEDIA) &&
@@ -2215,7 +2215,7 @@ class Compiler
      *
      * @return array|null
      */
-    private function fncall($name, $argValues)
+    protected function fncall($name, $argValues)
     {
         // SCSS @function
         if ($this->callScssFunction($name, $argValues, $returnValue)) {
@@ -3016,7 +3016,7 @@ class Compiler
      *
      * @return array
      */
-    private function compactEnv(Environment $env)
+    protected function compactEnv(Environment $env)
     {
         for ($envs = []; $env; $env = $env->parent) {
             $envs[] = $env;
@@ -3032,7 +3032,7 @@ class Compiler
      *
      * @return \Leafo\ScssPhp\Compiler\Environment
      */
-    private function extractEnv($envs)
+    protected function extractEnv($envs)
     {
         for ($env = null; $e = array_pop($envs);) {
             $e->parent = $env;
@@ -3864,7 +3864,7 @@ class Compiler
      *
      * @return array|\Leafo\ScssPhp\Node\Number
      */
-    private function coerceValue($value)
+    protected function coerceValue($value)
     {
         if (is_array($value) || $value instanceof \ArrayAccess) {
             return $value;
@@ -4203,7 +4203,7 @@ class Compiler
      *
      * @return float
      */
-    private function hueToRGB($m1, $m2, $h)
+    protected function hueToRGB($m1, $m2, $h)
     {
         if ($h < 0) {
             $h += 1;


### PR DESCRIPTION
Change private properties to protected in compiler class.

If Compiler class is extended, currently its impossible to access some methods and variables in child class because they are private. Changing it to protected makes it possible, while not affecting anything else.