### PR TITLE
Pr/leafo/627 : Add interpolation support selector

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -62,4 +62,8 @@ class Block
      * @var array
      */
     public $children;
+    /**
+     * @var \Leafo\ScssPhp\Block
+     */
+    public $selfParent;
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1919,6 +1919,20 @@ class Parser
         }
 
         $this->seek($s);
+
+        if ($this->literal('#{') && $this->selectorSingle($sel) && $this->literal('}', false)) {
+            $out = $sel[0];
+
+            $this->eatWhiteDefault = $oldWhite;
+
+            if ($this->eatWhiteDefault) {
+                $this->whitespace();
+            }
+
+            return true;
+        }
+
+        $this->seek($s);
         $this->eatWhiteDefault = $oldWhite;
 
         return false;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -763,6 +763,11 @@ class Parser
             $this->throwParseError('unexpected }');
         }
 
+        if ($block->type == Type::T_AT_ROOT) {
+            // keeps the parent in case of self selector &
+            $block->selfParent = $block->parent;
+        }
+
         $this->env = $block->parent;
         unset($block->parent);
 

--- a/tests/inputs/at_root.scss
+++ b/tests/inputs/at_root.scss
@@ -147,3 +147,9 @@ $table-padding: 10px !default;
     @include table;
   }
 }
+
+.badge {
+  @at-root a#{&} {
+    text-decoration: none;
+  }
+}

--- a/tests/inputs/interpolation.scss
+++ b/tests/inputs/interpolation.scss
@@ -97,3 +97,9 @@ $foo: ('a', 'b');
 div {
     prop: #{$foo};
 }
+
+.badge {
+  a#{&} {
+    text-decoration: none;
+  }
+}

--- a/tests/outputs/at_root.css
+++ b/tests/outputs/at_root.css
@@ -74,3 +74,6 @@ body .second {
   padding: 0px; }
   tbody {
     padding: 10px; }
+
+a.badge {
+  text-decoration: none; }

--- a/tests/outputs/interpolation.css
+++ b/tests/outputs/interpolation.css
@@ -61,3 +61,6 @@ foo, x, y {
 
 div {
   prop: a, b; }
+
+a.badge {
+  text-decoration: none; }

--- a/tests/outputs_numbered/at_root.css
+++ b/tests/outputs_numbered/at_root.css
@@ -107,3 +107,8 @@ margin: 0; } }
 /* line 139, inputs/at_root.scss */
   tbody {
     padding: 10px; }
+/* line 151, inputs/at_root.scss */
+/* line 152, inputs/at_root.scss */
+
+a.badge {
+  text-decoration: none; }

--- a/tests/outputs_numbered/interpolation.css
+++ b/tests/outputs_numbered/interpolation.css
@@ -71,3 +71,8 @@ foo, x, y {
 /* line 97, inputs/interpolation.scss */
 div {
   prop: a, b; }
+/* line 101, inputs/interpolation.scss */
+/* line 102, inputs/interpolation.scss */
+
+a.badge {
+  text-decoration: none; }


### PR DESCRIPTION
I fully reworked the proposal for PR #627 as it had no test case and it appears that the patch was causing `@at-root` directive to fail in some already existing tests
* Adding test-case for the interpolation `&{#}` selector without and with at-root parent
* keeping the PHPUnit version
* spliting the patch in several commits to make it more understandable

Tests are OK and PSR2 compliant.

I'm sorry i was not able to keep the credits to @kingyond as I really had do break the full patch in parts to understand how it was (not fully) working before being able to build this new patch, but the original commit really helped me!