### PR TITLE
Fix for #620

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2215,6 +2215,11 @@ class Compiler
             case Type::T_FUNCTION_CALL:
                 return $this->fncall($value[1], $value[2]);
 
+            case Type::T_SELF:
+                $selfSelector = $this->multiplySelectors($this->env);
+                $selfSelector = $this->collapseSelectors($selfSelector);
+                return [Type::T_STRING, '', [$selfSelector]];
+
             default:
                 return $value;
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1402,6 +1402,11 @@ class Parser
             }
         }
 
+        if ($this->matchChar('&', true)) {
+            $out = [Type::T_SELF];
+            return true;
+        }
+
         if ($char === '$' && $this->variable($out)) {
             return true;
         }
@@ -1991,14 +1996,18 @@ class Parser
         $s = $this->count;
 
         if ($this->literal('#{', 2) && $this->valueList($value) && $this->matchChar('}', false)) {
-            if ($lookWhite) {
-                $left = preg_match('/\s/', $this->buffer[$s - 1]) ? ' ' : '';
-                $right = preg_match('/\s/', $this->buffer[$this->count]) ? ' ': '';
+            if ($value === [Type::T_SELF]) {
+                $out = $value;
             } else {
-                $left = $right = false;
-            }
+                if ($lookWhite) {
+                    $left = preg_match('/\s/', $this->buffer[$s - 1]) ? ' ' : '';
+                    $right = preg_match('/\s/', $this->buffer[$this->count]) ? ' ': '';
+                } else {
+                    $left = $right = false;
+                }
 
-            $out = [Type::T_INTERPOLATE, $value, $left, $right];
+                $out = [Type::T_INTERPOLATE, $value, $left, $right];
+            }
             $this->eatWhiteDefault = $oldWhite;
 
             if ($this->eatWhiteDefault) {
@@ -2010,19 +2019,6 @@ class Parser
 
         $this->seek($s);
 
-        if ($this->literal('#{', 2) && $this->selectorSingle($sel) && $this->matchChar('}', false)) {
-            $out = $sel[0];
-
-            $this->eatWhiteDefault = $oldWhite;
-
-            if ($this->eatWhiteDefault) {
-                $this->whitespace();
-            }
-
-            return true;
-        }
-
-        $this->seek($s);
         $this->eatWhiteDefault = $oldWhite;
 
         return false;

--- a/tests/inputs/values.scss
+++ b/tests/inputs/values.scss
@@ -41,3 +41,8 @@ multiline string.";
     d: +foo(12px);
 }
 
+#self {
+    $self1: #{&};
+    $self2: &;
+    content:'#{$self2}';
+}

--- a/tests/outputs/values.css
+++ b/tests/outputs/values.css
@@ -32,3 +32,6 @@ multiline string.";
   b: 0.5em;
   c: -foo(12px);
   d: +foo(12px); }
+
+#self {
+  content: "#self"; }

--- a/tests/outputs_numbered/values.css
+++ b/tests/outputs_numbered/values.css
@@ -33,3 +33,6 @@ multiline string.";
   b: 0.5em;
   c: -foo(12px);
   d: +foo(12px); }
+/* line 44, inputs/values.scss */
+#self {
+  content: "#self"; }


### PR DESCRIPTION
unit test case, parser and compiler fix to allow to assign self `&` or `#{&}` to a variable