### PR TITLE
Issue/leafo/493

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1031,6 +1031,24 @@ class Compiler
         $this->scope = $this->makeOutputBlock($block->type, $selectors);
         $this->scope->parent->children[] = $this->scope;
 
+        // wrap assign children in a block
+        foreach ($block->children as $k => $child) {
+            if ($child[0] === Type::T_ASSIGN) {
+                $wrapped = new Block;
+                $wrapped->sourceName   = $block->sourceName;
+                $wrapped->sourceIndex  = $block->sourceIndex;
+                $wrapped->sourceLine   = $block->sourceLine;
+                $wrapped->sourceColumn = $block->sourceColumn;
+                $wrapped->selectors    = [];
+                $wrapped->comments     = [];
+                $wrapped->parent       = $block;
+                $wrapped->children     = [$child];
+                $wrapped->selfParent   = $block->selfParent;
+
+                $block->children[$k] = [Type::T_BLOCK, $wrapped];
+            }
+        }
+
         $this->compileChildrenNoReturn($block->children, $this->scope);
 
         $this->scope = $this->scope->parent;

--- a/tests/inputs/directives.scss
+++ b/tests/inputs/directives.scss
@@ -153,3 +153,22 @@ div {
 }
 
 }
+
+.sticky-top {
+  @supports (position: sticky) {
+    .top2 {
+      position: sticky;
+    }
+  }
+}
+.sticky-top {
+  @supports (position: sticky) {
+    position: sticky;
+  }
+}
+
+@supports (position: sticky) {
+  .sticky-top2 {
+    position: sticky;
+  }
+}

--- a/tests/outputs/directives.css
+++ b/tests/outputs/directives.css
@@ -22,6 +22,7 @@ div {
 
 @font-face {
   color: red;
+
   height: 20px; }
 
 @keyframes 'bounce' {
@@ -100,3 +101,15 @@ div {
       transform: scale(0.5); }
     to {
       transform: scale(1); } }
+
+@supports (position: sticky) {
+    .sticky-top .top2 {
+      position: sticky; } }
+
+@supports (position: sticky) {
+    .sticky-top {
+      position: sticky; } }
+
+@supports (position: sticky) {
+  .sticky-top2 {
+    position: sticky; } }

--- a/tests/outputs/scss_css.css
+++ b/tests/outputs/scss_css.css
@@ -63,9 +63,10 @@ sel {
   a: b; }
 
 @foo {
-  a: b;
   rule {
-    a: b; } }
+    a: b; }
+
+  a: b; }
 
 @foo {
   a: b; }
@@ -77,8 +78,11 @@ sel {
 
 foo {
   a: 12px calc(100%/3 - 2*1em - 2*1px);
+
   b: 12px -moz-calc(100%/3 - 2*1em - 2*1px);
+
   b: 12px -webkit-calc(100%/3 - 2*1em - 2*1px);
+
   b: 12px -foobar-calc(100%/3 - 2*1em - 2*1px); }
 
 foo {
@@ -154,7 +158,9 @@ foo {
 
 foo {
   a: -moz-element(#foo);
+
   b: -webkit-element(#foo);
+
   b: -foobar-element(#foo); }
 
 @foo ;
@@ -528,18 +534,22 @@ foo {
 
 @page {
   prop1: val;
+
   prop2: val; }
 
 @page flap {
   prop1: val;
+
   prop2: val; }
 
 @page :first {
   prop1: val;
+
   prop2: val; }
 
 @page flap:first {
   prop1: val;
+
   prop2: val; }
 
 .foo {

--- a/tests/outputs_numbered/directives.css
+++ b/tests/outputs_numbered/directives.css
@@ -26,6 +26,7 @@ height: 20px; } }
 
 @font-face {
   color: red;
+
   height: 20px; }
 
 @keyframes 'bounce' {
@@ -116,3 +117,17 @@ from {
 /* line 150, inputs/directives.scss */
 to {
   transform: scale(1); } }
+/* line 157, inputs/directives.scss */
+@supports (position: sticky) {
+/* line 159, inputs/directives.scss */
+.sticky-top .top2 {
+  position: sticky; } }
+/* line 164, inputs/directives.scss */
+@supports (position: sticky) {
+    .sticky-top {
+      position: sticky; } }
+
+@supports (position: sticky) {
+/* line 171, inputs/directives.scss */
+.sticky-top2 {
+  position: sticky; } }

--- a/tests/outputs_numbered/scss_css.css
+++ b/tests/outputs_numbered/scss_css.css
@@ -64,10 +64,10 @@ sel {
   a: b; }
 
 @foo {
-  a: b;
 /* line 65, inputs/scss_css.scss */
 rule {
-  a: b; } }
+  a: b; }
+a: b; }
 
 @foo {
   a: b; }
@@ -79,8 +79,11 @@ rule {
 
 foo {
   a: 12px calc(100%/3 - 2*1em - 2*1px);
+
   b: 12px -moz-calc(100%/3 - 2*1em - 2*1px);
+
   b: 12px -webkit-calc(100%/3 - 2*1em - 2*1px);
+
   b: 12px -foobar-calc(100%/3 - 2*1em - 2*1px); }
 /* line 84, inputs/scss_css.scss */
 foo {
@@ -163,7 +166,9 @@ foo {
 
 foo {
   a: -moz-element(#foo);
+
   b: -webkit-element(#foo);
+
   b: -foobar-element(#foo); }
 
 @foo ;
@@ -543,18 +548,22 @@ foo {
 
 @page {
   prop1: val;
+
   prop2: val; }
 
 @page flap {
   prop1: val;
+
   prop2: val; }
 
 @page :first {
   prop1: val;
+
   prop2: val; }
 
 @page flap:first {
   prop1: val;
+
   prop2: val; }
 /* line 688, inputs/scss_css.scss */
 .foo {


### PR DESCRIPTION
Fix https://github.com/leafo/scssphp/issues/493: assign lines in `@support` (or others) directives have to be wrapped in a block before compilation

There is a small change on the outpout of
```
@foo {
  rule {
    a: b; }

  a: b; }
```

which was
```
@foo {
  a: b; 
  rule {
    a: b; } }
```

and is now

```
@foo {
  rule {
    a: b; }

  a: b; }
```

which looks like not being worst: at least the order is kept, even if the result is however not valid in css