### PR TITLE
Issue/leafo/644v2

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -800,6 +800,7 @@ class Compiler
             $wrapped->selfParent   = $block->selfParent;
 
             $block->children = [[Type::T_BLOCK, $wrapped]];
+            $block->selector = null;
         }
 
         $this->env = $this->filterWithout($envs, $without);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -833,6 +833,10 @@ class Compiler
     {
         $filteredScopes = [];
 
+        if ($scope->type === TYPE::T_ROOT) {
+            return $scope;
+        }
+
         // start from the root
         while ($scope->parent && $scope->parent->type !== TYPE::T_ROOT) {
             $scope = $scope->parent;

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -808,7 +808,8 @@ class Compiler
         $saveScope   = $this->scope;
         $this->scope = $this->filterScopeWithout($saveScope, $without);
 
-        $this->compileChildrenNoReturn($block->children, $this->scope);
+        // propagate selfParent to the children where they still can be useful
+        $this->compileChildrenNoReturn($block->children, $this->scope, $block->selfParent);
 
         $this->scope = $this->completeScope($this->scope, $saveScope);
         $this->scope = $saveScope;
@@ -1137,8 +1138,8 @@ class Compiler
 
         if (count($block->children)) {
             $out->selectors = $this->multiplySelectors($env, $block->selfParent);
-
-            $this->compileChildrenNoReturn($block->children, $out);
+            // propagate selfParent to the children where they still can be useful
+            $this->compileChildrenNoReturn($block->children, $out, $block->selfParent);
         }
 
         $this->formatter->stripSemicolon($out->lines);
@@ -1395,12 +1396,17 @@ class Compiler
      *
      * @param array                                $stms
      * @param \Leafo\ScssPhp\Formatter\OutputBlock $out
+     * @param \Leafo\ScssPhp\Block $selfParent
      *
      * @throws \Exception
      */
-    protected function compileChildrenNoReturn($stms, OutputBlock $out)
+    protected function compileChildrenNoReturn($stms, OutputBlock $out, $selfParent = null)
     {
+
         foreach ($stms as $stm) {
+            if ($selfParent && isset($stm[1]) && is_object($stm[1]) && get_class($stm[1]) == 'Leafo\ScssPhp\Block') {
+                $stm[1]->selfParent = $selfParent;
+            }
             $ret = $this->compileChild($stm, $out);
 
             if (isset($ret)) {
@@ -1957,6 +1963,25 @@ class Compiler
                 $storeEnv = $this->storeEnv;
                 $this->storeEnv = $this->env;
 
+                // Find the parent selectors in the env to be able to know what '&' refers to in the mixin
+                $selfParent = null;
+                $selfParentSelectors = null;
+                $e = $this->env;
+                for (;;) {
+                    if (isset($e->selectors) && $e->selectors) {
+                        $selfParentSelectors = $e->selectors;
+                        break;
+                    }
+                    if (! $e->parent) {
+                        break;
+                    }
+                    $e = $e->parent;
+                }
+                if ($selfParentSelectors) {
+                    $selfParent = new Block();
+                    $selfParent->selectors = $selfParentSelectors;
+                }
+
                 if (isset($content)) {
                     $content->scope = $callingScope;
 
@@ -1970,7 +1995,7 @@ class Compiler
                 $this->env->marker = 'mixin';
 
                 $this->pushCallStack($this->env->marker . " " . $name);
-                $this->compileChildrenNoReturn($mixin->children, $out);
+                $this->compileChildrenNoReturn($mixin->children, $out, $selfParent);
                 $this->popCallStack();
 
                 $this->storeEnv = $storeEnv;
@@ -3050,7 +3075,14 @@ class Compiler
                         }
 
                         foreach ($parentPart as $pp) {
-                            $newPart[] = (is_array($pp) ? implode($pp) : $pp);
+                            if (is_array($pp)) {
+                                $flatten = [];
+                                array_walk_recursive($pp, function ($a) use (&$flatten) {
+                                    $flatten[] = $a;
+                                });
+                                $pp = implode($flatten);
+                            }
+                            $newPart[] = $pp;
                         }
                     }
                 } else {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1424,11 +1424,16 @@ class Compiler
         foreach ($stms as $stm) {
             if ($selfParent && isset($stm[1]) && is_object($stm[1]) && get_class($stm[1]) == 'Leafo\ScssPhp\Block') {
                 $stm[1]->selfParent = $selfParent;
+                $ret = $this->compileChild($stm, $out);
+                $stm[1]->selfParent = null;
             }
-            if ($selfParent && $stm[0] === TYPE::T_INCLUDE) {
+            elseif ($selfParent && $stm[0] === TYPE::T_INCLUDE) {
                 $stm['selfParent'] = $selfParent;
+                $ret = $this->compileChild($stm, $out);
+                unset($stm['selfParent']);
+            } else {
+                $ret = $this->compileChild($stm, $out);
             }
-            $ret = $this->compileChild($stm, $out);
 
             if (isset($ret)) {
                 $this->throwError('@return may only be used within a function');

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1139,7 +1139,16 @@ class Compiler
         if (count($block->children)) {
             $out->selectors = $this->multiplySelectors($env, $block->selfParent);
             // propagate selfParent to the children where they still can be useful
+            $selfParentSelectors = null;
+            if (isset($block->selfParent->selectors)) {
+                $selfParentSelectors = $block->selfParent->selectors;
+                $block->selfParent->selectors = $out->selectors;
+            }
             $this->compileChildrenNoReturn($block->children, $out, $block->selfParent);
+            // and revert for the following childs of the same block
+            if ($selfParentSelectors) {
+                $block->selfParent->selectors = $selfParentSelectors;
+            }
         }
 
         $this->formatter->stripSemicolon($out->lines);

--- a/tests/inputs/at_root.scss
+++ b/tests/inputs/at_root.scss
@@ -214,3 +214,9 @@ $table-padding: 10px !default;
   }
 
 }
+// check that the hover-focus has not been spoiled by previous @at-root call
+.btn {
+  @include hover-focus {
+    text-decoration: none;
+  }
+}

--- a/tests/inputs/at_root.scss
+++ b/tests/inputs/at_root.scss
@@ -188,3 +188,29 @@ $table-padding: 10px !default;
     }
   }
 }
+
+// self propagation to @include and previous media poisoning in @at-root
+@mixin transition($transition...) {
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+}
+
+@mixin hover-focus {
+  &:hover,
+  &:focus {
+    @content;
+  }
+}
+
+.badge {
+  display: inline-block;
+  @include transition(none);
+
+  @at-root a#{&} {
+    @include hover-focus {
+      text-decoration: none;
+    }
+  }
+
+}

--- a/tests/inputs/at_root.scss
+++ b/tests/inputs/at_root.scss
@@ -153,3 +153,21 @@ $table-padding: 10px !default;
     text-decoration: none;
   }
 }
+
+@mixin badge-variant($bg) {
+  background-color: $bg;
+
+  @at-root a#{&} {
+    &:focus,
+    &.focus {
+      outline: 0;
+    }
+  }
+}
+
+.badge-primary {
+	@include badge-variant(blue);
+}
+.badge-secondary {
+	@include badge-variant(yellow);
+}

--- a/tests/inputs/at_root.scss
+++ b/tests/inputs/at_root.scss
@@ -171,3 +171,20 @@ $table-padding: 10px !default;
 .badge-secondary {
 	@include badge-variant(yellow);
 }
+
+// combine everything in one: several levels of selecors, mixin, at-root and self
+@mixin mixin-hover {
+  &:hover { @content; }
+  @at-root #{&}.foo {
+	color:red;
+  }
+}
+
+.table-hover, .table2#id {
+  tbody tr {
+    @include mixin-hover {
+      color: #ddd;
+      background-color: #eee;
+    }
+  }
+}

--- a/tests/inputs/interpolation.scss
+++ b/tests/inputs/interpolation.scss
@@ -119,3 +119,17 @@ div {
 .btn-primary {
     @include button-variant(yellow);
 }
+
+@mixin pagination-mixin($border-radius) {
+  .page-item {
+    &:first-child {
+      .page-link {
+        border-radius: $border-radius;
+      }
+    }
+  }
+}
+
+.pagination {
+  @include pagination-mixin(5px);
+}

--- a/tests/inputs/interpolation.scss
+++ b/tests/inputs/interpolation.scss
@@ -103,3 +103,19 @@ div {
     text-decoration: none;
   }
 }
+
+@mixin button-variant($background) {
+  background: $background;
+
+  &:not(.disabled) {
+    border-color: red;
+
+    &:focus {
+	border-width: 3px;
+    }
+  }
+}
+
+.btn-primary {
+    @include button-variant(yellow);
+}

--- a/tests/outputs/at_root.css
+++ b/tests/outputs/at_root.css
@@ -103,3 +103,9 @@ a.badge {
     a.badge-secondary:focus, a.badge-secondary.focus {
       outline: 0; }
 
+.table-hover tbody tr:hover, .table2#id tbody tr:hover {
+  color: #ddd;
+  background-color: #eee; }
+      .table-hover tbody tr.foo, .table2#id tbody tr.foo {
+        color: red; }
+

--- a/tests/outputs/at_root.css
+++ b/tests/outputs/at_root.css
@@ -104,3 +104,6 @@ a.badge {
     transition: none; } }
   a.badge:hover, a.badge:focus {
     text-decoration: none; }
+
+.btn:hover, .btn:focus {
+  text-decoration: none; }

--- a/tests/outputs/at_root.css
+++ b/tests/outputs/at_root.css
@@ -1,17 +1,16 @@
 .parent-inline-selector {
   color: white; }
-    .child {
-      color: black; }
+  .child {
+    color: black; }
 
 .parent-block {
   color: white; }
-    .child1 {
-      color: green; }
-    .child2 {
-      color: blue; }
-
-.parent-block .step-child {
-  color: black; }
+  .child1 {
+    color: green; }
+  .child2 {
+    color: blue; }
+  .parent-block .step-child {
+    color: black; }
 
 .first {
   color: red; }
@@ -19,12 +18,11 @@
 body .second {
   color: white;
   color: black; }
-      .nested1 {
-        color: blue;
-        color: orange; }
-
-.nested2 {
-  color: yellow; }
+  .nested1 {
+    color: blue;
+    color: orange; }
+    .nested2 {
+      color: yellow; }
 
 .third {
   color: green; }
@@ -32,23 +30,19 @@ body .second {
 @media print {
   .page {
     width: 8in; } }
-
-.page {
-  color: red; }
+  .page {
+    color: red; }
 
 @media (min-width: 300px) {
     .my-widget .inside-mq {
       inside-style: mq; } }
-
-      .my-widget .outside-mq {
-        outside-style: mq; }
-
-.outside-class {
-  color: blue; }
-
-@media (min-width: 300px) {
-        .with-only {
-          color: pink; } }
+    .my-widget .outside-mq {
+      outside-style: mq; }
+    .outside-class {
+      color: blue; }
+  @media (min-width: 300px) {
+      .with-only {
+        color: pink; } }
 
 @media screen and (max-width: 320px) {
   .foo {
@@ -57,21 +51,17 @@ body .second {
 @media screen and (max-width: 320px) {
       .bar {
         padding: 0; } }
-
-.baar {
-  padding: 0; }
-
-    .foo .barr {
-      padding: 0; }
+  .baar {
+    padding: 0; }
+  .foo .barr {
+    padding: 0; }
 
 
-
-.foo .bar {
-  width: 0; }
-
-@supports ( display: flex ) {
-        .baz {
-          height: 0; } }
+  .foo .bar {
+    width: 0; }
+  @supports ( display: flex ) {
+      .baz {
+        height: 0; } }
 
 @media screen and (max-width: 640px) {
         .qux {
@@ -80,32 +70,29 @@ body .second {
 @media screen and (max-width: 640px) {
         .foo .quux {
           padding: 0; } }
-
-.foo .quix {
-  padding: 0; }
+  .foo .quix {
+    padding: 0; }
 
 .test .test2 {
   padding: 0px; }
-      tbody {
-        padding: 10px; }
+  tbody {
+    padding: 10px; }
 
 a.badge {
   text-decoration: none; }
 
-
 .badge-primary {
   background-color: blue; }
-    a.badge-primary:focus, a.badge-primary.focus {
-      outline: 0; }
+  a.badge-primary:focus, a.badge-primary.focus {
+    outline: 0; }
 
 .badge-secondary {
   background-color: yellow; }
-    a.badge-secondary:focus, a.badge-secondary.focus {
-      outline: 0; }
+  a.badge-secondary:focus, a.badge-secondary.focus {
+    outline: 0; }
 
 .table-hover tbody tr:hover, .table2#id tbody tr:hover {
   color: #ddd;
   background-color: #eee; }
-      .table-hover tbody tr.foo, .table2#id tbody tr.foo {
-        color: red; }
-
+  .table-hover tbody tr.foo, .table2#id tbody tr.foo {
+    color: red; }

--- a/tests/outputs/at_root.css
+++ b/tests/outputs/at_root.css
@@ -96,3 +96,11 @@ a.badge {
   background-color: #eee; }
   .table-hover tbody tr.foo, .table2#id tbody tr.foo {
     color: red; }
+
+.badge {
+  display: inline-block; }
+  @media (prefers-reduced-motion: reduce) {
+  .badge {
+    transition: none; } }
+  a.badge:hover, a.badge:focus {
+    text-decoration: none; }

--- a/tests/outputs/at_root.css
+++ b/tests/outputs/at_root.css
@@ -92,3 +92,14 @@ body .second {
 a.badge {
   text-decoration: none; }
 
+
+.badge-primary {
+  background-color: blue; }
+    a.badge-primary:focus, a.badge-primary.focus {
+      outline: 0; }
+
+.badge-secondary {
+  background-color: yellow; }
+    a.badge-secondary:focus, a.badge-secondary.focus {
+      outline: 0; }
+

--- a/tests/outputs/interpolation.css
+++ b/tests/outputs/interpolation.css
@@ -71,3 +71,6 @@ a.badge {
     border-color: red; }
     .btn-primary:not(.disabled):focus {
       border-width: 3px; }
+
+.pagination .page-item:first-child .page-link {
+  border-radius: 5px; }

--- a/tests/outputs/interpolation.css
+++ b/tests/outputs/interpolation.css
@@ -64,3 +64,10 @@ div {
 
 a.badge {
   text-decoration: none; }
+
+.btn-primary {
+  background: yellow; }
+  .btn-primary:not(.disabled) {
+    border-color: red; }
+    .btn-primary:not(.disabled):focus {
+      border-width: 3px; }

--- a/tests/outputs_numbered/at_root.css
+++ b/tests/outputs_numbered/at_root.css
@@ -118,3 +118,19 @@ tbody {
 a.badge {
 text-decoration: none; }
 
+/* line 168, inputs/at_root.scss */
+.badge-primary {
+  background-color: blue; }
+/* line 160, inputs/at_root.scss */
+/* line 161, inputs/at_root.scss */
+  a.badge-primary:focus, a.badge-primary.focus {
+    outline: 0; }
+
+/* line 171, inputs/at_root.scss */
+.badge-secondary {
+  background-color: yellow; }
+/* line 160, inputs/at_root.scss */
+/* line 161, inputs/at_root.scss */
+  a.badge-secondary:focus, a.badge-secondary.focus {
+    outline: 0; }
+

--- a/tests/outputs_numbered/at_root.css
+++ b/tests/outputs_numbered/at_root.css
@@ -134,3 +134,15 @@ text-decoration: none; }
   a.badge-secondary:focus, a.badge-secondary.focus {
     outline: 0; }
 
+/* line 183, inputs/at_root.scss */
+/* line 184, inputs/at_root.scss */
+
+/* line 177, inputs/at_root.scss */
+
+.table-hover tbody tr:hover, .table2#id tbody tr:hover {
+  color: #ddd;
+  background-color: #eee; }
+/* line 178, inputs/at_root.scss */
+.table-hover tbody tr.foo, .table2#id tbody tr.foo {
+  color: red; }
+

--- a/tests/outputs_numbered/at_root.css
+++ b/tests/outputs_numbered/at_root.css
@@ -141,3 +141,15 @@ a.badge-secondary:focus, a.badge-secondary.focus {
 /* line 178, inputs/at_root.scss */
 .table-hover tbody tr.foo, .table2#id tbody tr.foo {
   color: red; }
+/* line 206, inputs/at_root.scss */
+.badge {
+  display: inline-block; }
+
+@media (prefers-reduced-motion: reduce) {
+    .badge {
+      transition: none; } }
+/* line 210, inputs/at_root.scss */
+/* line 200, inputs/at_root.scss */
+
+a.badge:hover, a.badge:focus {
+  text-decoration: none; }

--- a/tests/outputs_numbered/at_root.css
+++ b/tests/outputs_numbered/at_root.css
@@ -153,3 +153,8 @@ a.badge-secondary:focus, a.badge-secondary.focus {
 
 a.badge:hover, a.badge:focus {
   text-decoration: none; }
+/* line 218, inputs/at_root.scss */
+/* line 200, inputs/at_root.scss */
+
+.btn:hover, .btn:focus {
+  text-decoration: none; }

--- a/tests/outputs_numbered/at_root.css
+++ b/tests/outputs_numbered/at_root.css
@@ -4,7 +4,6 @@
 /* line 3, inputs/at_root.scss */
 .child {
   color: black; }
-
 /* line 6, inputs/at_root.scss */
 .parent-block {
   color: white; }
@@ -14,7 +13,6 @@
 /* line 10, inputs/at_root.scss */
 .child2 {
   color: blue; }
-
 /* line 12, inputs/at_root.scss */
 .parent-block .step-child {
   color: black; }
@@ -31,7 +29,6 @@ body .second {
 .nested1 {
   color: blue;
   color: orange; }
-
 /* line 26, inputs/at_root.scss */
 .nested2 {
   color: yellow; }
@@ -112,28 +109,27 @@ padding: 0; }
 /* line 139, inputs/at_root.scss */
 tbody {
   padding: 10px; }
-
 /* line 151, inputs/at_root.scss */
 /* line 152, inputs/at_root.scss */
-a.badge {
-text-decoration: none; }
 
+a.badge {
+  text-decoration: none; }
 /* line 168, inputs/at_root.scss */
 .badge-primary {
   background-color: blue; }
 /* line 160, inputs/at_root.scss */
 /* line 161, inputs/at_root.scss */
-  a.badge-primary:focus, a.badge-primary.focus {
-    outline: 0; }
 
+a.badge-primary:focus, a.badge-primary.focus {
+  outline: 0; }
 /* line 171, inputs/at_root.scss */
 .badge-secondary {
   background-color: yellow; }
 /* line 160, inputs/at_root.scss */
 /* line 161, inputs/at_root.scss */
-  a.badge-secondary:focus, a.badge-secondary.focus {
-    outline: 0; }
 
+a.badge-secondary:focus, a.badge-secondary.focus {
+  outline: 0; }
 /* line 183, inputs/at_root.scss */
 /* line 184, inputs/at_root.scss */
 
@@ -145,4 +141,3 @@ text-decoration: none; }
 /* line 178, inputs/at_root.scss */
 .table-hover tbody tr.foo, .table2#id tbody tr.foo {
   color: red; }
-

--- a/tests/outputs_numbered/interpolation.css
+++ b/tests/outputs_numbered/interpolation.css
@@ -76,3 +76,12 @@ div {
 
 a.badge {
   text-decoration: none; }
+/* line 119, inputs/interpolation.scss */
+.btn-primary {
+  background: yellow; }
+/* line 110, inputs/interpolation.scss */
+.btn-primary:not(.disabled) {
+  border-color: red; }
+/* line 113, inputs/interpolation.scss */
+.btn-primary:not(.disabled):focus {
+  border-width: 3px; }

--- a/tests/outputs_numbered/interpolation.css
+++ b/tests/outputs_numbered/interpolation.css
@@ -85,3 +85,11 @@ a.badge {
 /* line 113, inputs/interpolation.scss */
 .btn-primary:not(.disabled):focus {
   border-width: 3px; }
+/* line 133, inputs/interpolation.scss */
+/* line 124, inputs/interpolation.scss */
+
+/* line 125, inputs/interpolation.scss */
+
+/* line 126, inputs/interpolation.scss */
+  .pagination .page-item:first-child .page-link {
+    border-radius: 5px; }


### PR DESCRIPTION
This is now really fixin #644 as I checked the whole compilation of BS4 and fixed each bug in the output css.

The compilation with scssphp now only differs from the dist css file on the following points:
* quote on some fonts name `BlinkMacSystemFont, Segoe UI, Roboto` vs `BlinkMacSystemFont, "Segoe UI", Roboto`
* precision on float value `.3333333333`
* leading zero values `0.5rem` vs  `.5rem`
* some combinations of selectors not in the same order (eg `input-group >...`)
* some slight differences on the color computation like `#ffe7a0` vs `#ffe8a1`
* spaces, newlines and indentation

and also of course the prefixed properties, selectors and values that are in the dist bootstrap.css

I think we can say it's an acceptable result :)
