### PR TITLE
Version 0.8.0 

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -18,5 +18,5 @@ namespace Leafo\ScssPhp;
  */
 class Version
 {
-    const VERSION = 'v0.7.9';
+    const VERSION = 'v0.8.0';
 }


### PR DESCRIPTION
I propose to tag this curent state as a v0.8.0 as there has been a lot of improvements and fixes (and it now includes BS4 & Foundation compilation in test cases)
Then you can increment the master branch to v0.8.1 for further developments