### PR TITLE
Moving `commentsSeen` property

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -146,7 +146,6 @@ class Compiler
     protected $sourceNames;
 
     protected $indentLevel;
-    protected $commentsSeen;
     protected $extends;
     protected $extendsMap;
     protected $parsedFiles;
@@ -182,7 +181,6 @@ class Compiler
     public function compile($code, $path = null)
     {
         $this->indentLevel    = -1;
-        $this->commentsSeen   = [];
         $this->extends        = [];
         $this->extendsMap     = [];
         $this->sourceIndex    = null;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -65,7 +65,7 @@ class Parser
     private $utf8;
     private $encoding;
     private $patternModifiers;
-    protected $commentsSeen;
+    private $commentsSeen;
 
     /**
      * Constructor

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -65,6 +65,7 @@ class Parser
     private $utf8;
     private $encoding;
     private $patternModifiers;
+    protected $commentsSeen;
 
     /**
      * Constructor
@@ -82,6 +83,7 @@ class Parser
         $this->charset          = null;
         $this->utf8             = ! $encoding || strtolower($encoding) === 'utf-8';
         $this->patternModifiers = $this->utf8 ? 'Aisu' : 'Ais';
+        $this->commentsSeen   = [];
 
         if (empty(static::$operatorPattern)) {
             static::$operatorPattern = '([*\/%+-]|[!=]\=|\>\=?|\<\=\>|\<\=?|and|or)';


### PR DESCRIPTION
Moiving `commentSeen` property from `Compiler` to `Parser` as it used only in the `Parser`.

Fixes: #661 