### PR TITLE
Fix #490

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3428,7 +3428,11 @@ class Compiler
         $nextIsRoot = false;
         $hasNamespace = $normalizedName[0] === '^' || $normalizedName[0] === '@' || $normalizedName[0] === '%';
 
+        $max_depth = 10000;
         for (;;) {
+            if ($max_depth-- <= 0) {
+                break;
+            }
             if (array_key_exists($normalizedName, $env->store)) {
                 if ($unreduced && isset($env->storeUnreduced[$normalizedName])) {
                     return $env->storeUnreduced[$normalizedName];

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2074,10 +2074,13 @@ class Compiler
                     }
                 }
 
+                // the content stored need to be cloned to not have its scope spoiled by a further call to the same mixin
+                // ie recursive @include of the same mixin
                 if (isset($content)) {
-                    $content->scope = $callingScope;
+                    $copy_content = clone $content;
+                    $copy_content->scope = $callingScope;
 
-                    $this->setRaw(static::$namespaces['special'] . 'content', $content, $this->env);
+                    $this->setRaw(static::$namespaces['special'] . 'content', $copy_content, $this->env);
                 }
 
                 if (isset($mixin->args)) {


### PR DESCRIPTION
Was a good mix of several issues :)
* infinite loop in var resolution if the `->parent` chain was cycling
* `@include` scope of mixin spoiled by a further call of the same in case of recursivity, producing the previous bug
* `@media` compilation was needing to evaluate each expression with it's own scope

I have good hope this could also solve some other issues involving recursive mixin calls and/or `@media` with interpolation