### PR TITLE
define a upper bound for the php version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr-4": { "Leafo\\ScssPhp\\Test\\": "tests/" }
     },
     "require": {
-        "php": ">=5.6.0"
+        "php": "^5.6.0 || ^7"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.5",


### PR DESCRIPTION
Php8 is alreay in the works and since this lib is not yet known to be compatible with it we should explicitly define that