### PR TITLE
Fix Issue/leafo/432

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3927,7 +3927,8 @@ class Compiler
      * @param null $limit
      * @return string
      */
-    protected function callStackMessage($all = false, $limit = null) {
+    protected function callStackMessage($all = false, $limit = null)
+    {
         $callStackMsg = [];
         $ncall = 0;
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1451,7 +1451,7 @@ class Compiler
           Parser::SOURCE_COLUMN => $this->sourceColumn
         ];
         // infinite calling loop
-        if (count($this->callStack) > 1000) {
+        if (count($this->callStack) > 25000) {
             // not displayed but you can var_dump it to deep debug
             $msg = $this->callStackMessage(true, 100);
             $msg = "Infinite calling loop";

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2181,8 +2181,7 @@ class Compiler
                 break;
 
             case Type::T_MIXIN_CONTENT:
-                $content = $this->get(static::$namespaces['special'] . 'content', false, $this->getStoreEnv())
-                         ?: $this->get(static::$namespaces['special'] . 'content', false, $this->env);
+                $content = $this->get(static::$namespaces['special'] . 'content', false, isset($this->storeEnv) ? $this->storeEnv : $this->env);
 
                 if (! $content) {
                     $content = new \stdClass();


### PR DESCRIPTION
Fix #432: infinite recursion in nested @include/@content pattern due to a mistaken env picking
+ improve the debugging capabilities by having a full calling stack and throwing an error in case of the stack being larger than a thresold  - which has good chance to be a clue of infinite recursion.

(but the compilation of Foundation needs to get a stack length thresold of 25000, which is telling something about the framework complexity I guess)