### PR TITLE
Fix proposal for #475: generate line number in wrapped media blocks w…

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -757,6 +757,30 @@ class Compiler
                 $wrapped->children     = $media->children;
 
                 $media->children = [[Type::T_BLOCK, $wrapped]];
+                if (isset($this->lineNumberStyle)) {
+                    $annotation = $this->makeOutputBlock(Type::T_COMMENT);
+                    $annotation->depth = 0;
+
+                    $file = $this->sourceNames[$media->sourceIndex];
+                    $line = $media->sourceLine;
+
+                    switch ($this->lineNumberStyle) {
+                        case static::LINE_COMMENTS:
+                            $annotation->lines[] = '/* line ' . $line
+                                                 . ($file ? ', ' . $file : '')
+                                                 . ' */';
+                            break;
+
+                        case static::DEBUG_INFO:
+                            $annotation->lines[] = '@media -sass-debug-info{'
+                                                 . ($file ? 'filename{font-family:"' . $file . '"}' : '')
+                                                 . 'line{font-family:' . $line . '}}';
+                            break;
+                    }
+
+                    $this->scope->children[] = $annotation;
+                }
+
             }
 
             $this->compileChildrenNoReturn($media->children, $this->scope);

--- a/tests/outputs_numbered/at_root.css
+++ b/tests/outputs_numbered/at_root.css
@@ -45,9 +45,10 @@ body .second {
   color: red; }
 /* line 49, inputs/at_root.scss */
 @media (min-width: 300px) {
-    /* line 51, inputs/at_root.scss */
-      .my-widget .inside-mq {
-        inside-style: mq; } }
+/* line 50, inputs/at_root.scss */
+/* line 51, inputs/at_root.scss */
+  .my-widget .inside-mq {
+    inside-style: mq; } }
 
 /* line 56, inputs/at_root.scss */
 .my-widget .outside-mq {
@@ -146,8 +147,9 @@ a.badge-secondary:focus, a.badge-secondary.focus {
   display: inline-block; }
 
 @media (prefers-reduced-motion: reduce) {
-    .badge {
-      transition: none; } }
+/* line 194, inputs/at_root.scss */
+.badge {
+  transition: none; } }
 /* line 210, inputs/at_root.scss */
 /* line 200, inputs/at_root.scss */
 

--- a/tests/outputs_numbered/content.css
+++ b/tests/outputs_numbered/content.css
@@ -9,9 +9,10 @@
   border-color: blue; }
 
 @media only screen and (max-width: 480px) {
-  /* line 32, inputs/content.scss */
-    body {
-      color: red; } }
+/* line 26, inputs/content.scss */
+/* line 32, inputs/content.scss */
+  body {
+    color: red; } }
 /* line 36, inputs/content.scss */
 #sidebar {
   width: 300px; }
@@ -20,9 +21,10 @@
     width: 100px; } }
 
 @media only screen and (min-width: 40em) {
-  /* line 51, inputs/content.scss */
-    .grid-1 {
-      width: 100%; }
+/* line 46, inputs/content.scss */
+/* line 51, inputs/content.scss */
+  .grid-1 {
+    width: 100%; }
 /* line 51, inputs/content.scss */
 .grid-2 {
   width: 100%; } }

--- a/tests/outputs_numbered/media.css
+++ b/tests/outputs_numbered/media.css
@@ -24,15 +24,18 @@ div {
   color: blue; } }
 
 @media (max-width: 940px) {
-  color: red; }
+/* line 23, inputs/media.scss */
+color: red; }
 
 @media not hello and (world) {
-  color: blue;
+/* line 28, inputs/media.scss */
+color: blue;
 /* line 30, inputs/media.scss */
 pre {
   color: blue; } }
   @media butt and (world) {
-    color: red;
+/* line 34, inputs/media.scss */
+color: red;
 /* line 36, inputs/media.scss */
 div {
 color: red; } }
@@ -49,10 +52,11 @@ width: 500px; } }
 div {
   position: absolute; }
   @media screen {
-  div {
-    top: 0;
-    bottom: 8em;
-    color: red; }
+/* line 84, inputs/media.scss */
+div {
+top: 0;
+bottom: 8em;
+color: red; }
 /* line 87, inputs/media.scss */
 div p {
 margin: 5px; }
@@ -69,23 +73,26 @@ color: green; } }
   background: #aaa; }
 
 @media only screen and (max-width: 300px) {
-    .button {
-      width: 100px;
-      height: 100px; } }
+/* line 104, inputs/media.scss */
+.button {
+  width: 100px;
+  height: 100px; } }
 /* line 110, inputs/media.scss */
 code {
   position: absolute; }
 
 @media screen {
-    code {
-      height: 10px; }
+/* line 112, inputs/media.scss */
+code {
+  height: 10px; }
 /* line 113, inputs/media.scss */
 code pre {
   height: 20px; } }
 /* line 120, inputs/media.scss */
 @media screen and (color: blue) {
-      dt {
-        height: 10px; } }
+/* line 122, inputs/media.scss */
+dt {
+  height: 10px; } }
 
 @media screen {
 /* line 130, inputs/media.scss */

--- a/tests/outputs_numbered/mixins.css
+++ b/tests/outputs_numbered/mixins.css
@@ -106,8 +106,9 @@ div.parameter-name-scope {
   color: red; } }
 /* line 190, inputs/mixins.scss */
 @media screen and (min-width:0\0) {
-    .test {
-      color: #000; } }
+/* line 186, inputs/mixins.scss */
+.test {
+  color: #000; } }
 /* line 197, inputs/mixins.scss */
 div {
   content: "div";

--- a/tests/outputs_numbered/nested_mixins.css
+++ b/tests/outputs_numbered/nested_mixins.css
@@ -14,10 +14,11 @@ div .container .bar {
   width: 12px; }
 
 @media print, screen and (min-width:640px) {
-  /* line 43, inputs/nested_mixins.scss */
-    .position-left {
-      color: red;
-      background: yellow; } }
+/* line 33, inputs/nested_mixins.scss */
+/* line 43, inputs/nested_mixins.scss */
+  .position-left {
+    color: red;
+    background: yellow; } }
 
 @media print, screen and (min-width:640px) {
 /* line 45, inputs/nested_mixins.scss */

--- a/tests/outputs_numbered/scss_css.css
+++ b/tests/outputs_numbered/scss_css.css
@@ -364,10 +364,12 @@ rule2 {
   prop: val; } }
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  a: b; }
+/* line 440, inputs/scss_css.scss */
+a: b; }
 
 @media only screen, print and (foo: 0px) and (bar: flam(12px solid)) {
-  a: b; }
+/* line 444, inputs/scss_css.scss */
+a: b; }
 /* line 448, inputs/scss_css.scss */
 :-moz-any(h1, h2, h3) {
   a: b; }


### PR DESCRIPTION
…ith option --line-numbers

I'm not sure if this is matching the initial intention, but the patch allow additionnal line number in comments on wrapped `@media` block (mainly when a `@media` is nested in a block just encapsuling assignments).

The test have to be generated again as the output numbered are changed