### PR TITLE
Fix proposal for #598

### DIFF
--- a/src/Formatter/Compressed.php
+++ b/src/Formatter/Compressed.php
@@ -59,4 +59,18 @@ class Compressed extends Formatter
             $this->write($this->break);
         }
     }
+
+    /**
+     * Output block selectors
+     *
+     * @param \Leafo\ScssPhp\Formatter\OutputBlock $block
+     */
+    protected function blockSelectors(OutputBlock $block)
+    {
+        $inner = $this->indentStr();
+
+        $this->write($inner
+            . implode($this->tagSeparator, str_replace(array(' > ', ' + ', ' ~ '), array('>', '+', '~'), $block->selectors))
+            . $this->open . $this->break);
+    }
 }

--- a/src/Formatter/Crunched.php
+++ b/src/Formatter/Crunched.php
@@ -57,4 +57,18 @@ class Crunched extends Formatter
             $this->write($this->break);
         }
     }
+
+    /**
+     * Output block selectors
+     *
+     * @param \Leafo\ScssPhp\Formatter\OutputBlock $block
+     */
+    protected function blockSelectors(OutputBlock $block)
+    {
+        $inner = $this->indentStr();
+
+        $this->write($inner
+            . implode($this->tagSeparator, str_replace(array(' > ', ' + ', ' ~ '), array('>', '+', '~'), $block->selectors))
+            . $this->open . $this->break);
+    }
 }


### PR DESCRIPTION
As relationshop operators in selectors are recombined in the compiler itself, the space around coming from the general gluing rule for selector part, it seems hard to break everything to make this buble up until the Formatter.

But I think a simple str_replace() in the Formatter is safe here and get the improvement at low cost.