### PR TITLE
Selector functions implementation

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6072,10 +6072,10 @@ class Compiler
     {
         // one and only one selector for each arg
         if (! $super || count($super) !== 1) {
-            return false;
+            $this->throwError("Invalid super selector for isSuperSelector()");
         }
         if (! $sub || count($sub) !== 1) {
-            return false;
+            $this->throwError("Invalid sub selector for isSuperSelector()");
         }
         $super = $this->glueFunctionSelectors($super);
         $sub = $this->glueFunctionSelectors($sub);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6309,6 +6309,236 @@ class Compiler
         return $this->formatOutputSelector($selectors);
     }
 
+    protected static $libSelectorUnify = ['selectors1', 'selectors2'];
+    protected function libSelectorUnify($args)
+    {
+        list($selectors1, $selectors2) = $args;
+        $selectors1 = $this->getSelectorArg($selectors1);
+        $selectors2 = $this->getSelectorArg($selectors2);
+
+        if (! $selectors1 || ! $selectors2) {
+            $this->throwError("selector-unify() invalid arguments");
+        }
+
+        // only consider the first compound of each
+        $compound1 = reset($selectors1);
+        $compound2 = reset($selectors2);
+
+        // unify them and that's it
+        $unified = $this->unifyCompoundSelectors($compound1, $compound2);
+
+        return $this->formatOutputSelector($unified);
+    }
+
+    /**
+     * The selector-unify magic as its best
+     * (at least works as expected on test cases)
+     *
+     * @param array $compound1
+     * @param array $compound2
+     * @return array|mixed
+     */
+    protected function unifyCompoundSelectors($compound1, $compound2)
+    {
+
+        if (!count($compound1)) {
+            return $compound2;
+        }
+        if (!count($compound2)) {
+            return $compound1;
+        }
+
+        // check that last part are compatible
+        $lastPart1 = array_pop($compound1);
+        $lastPart2 = array_pop($compound2);
+        $last = $this->mergeParts($lastPart1, $lastPart2);
+        if (!$last) {
+            return [[]];
+        }
+        $unifiedCompound = [$last];
+        $unifiedSelectors = [$unifiedCompound];
+
+        // do the rest
+        while (count($compound1) || count($compound2)) {
+            $part1 = end($compound1);
+            $part2 = end($compound2);
+            if ($part1 && ($match2 = $this->matchPartInCompound($part1, $compound2))) {
+                list($compound2, $part2, $after2) = $match2;
+                if ($after2) {
+                    $unifiedSelectors = $this->prependSelectors($unifiedSelectors, $after2);
+                }
+                $c = $this->mergeParts($part1, $part2);
+                $unifiedSelectors = $this->prependSelectors($unifiedSelectors, [$c]);
+                $part1 = $part2 = null;
+                array_pop($compound1);
+            }
+            if ($part2 && ($match1 = $this->matchPartInCompound($part2, $compound1))) {
+                list($compound1, $part1, $after1) = $match1;
+                if ($after1) {
+                    $unifiedSelectors = $this->prependSelectors($unifiedSelectors, $after1);
+                }
+                $c = $this->mergeParts($part2, $part1);
+                $unifiedSelectors = $this->prependSelectors($unifiedSelectors, [$c]);
+                $part1 = $part2 = null;
+                array_pop($compound2);
+            }
+            $new = [];
+            if ($part1 && $part2) {
+                array_pop($compound1);
+                array_pop($compound2);
+                $s = $this->prependSelectors($unifiedSelectors, [$part2]);
+                $new = array_merge($new, $this->prependSelectors($s, [$part1]));
+                $s = $this->prependSelectors($unifiedSelectors, [$part1]);
+                $new = array_merge($new, $this->prependSelectors($s, [$part2]));
+            } elseif ($part1) {
+                array_pop($compound1);
+                $new = array_merge($new, $this->prependSelectors($unifiedSelectors, [$part1]));
+            } elseif ($part2) {
+                array_pop($compound2);
+                $new = array_merge($new, $this->prependSelectors($unifiedSelectors, [$part2]));
+            }
+            if ($new) {
+                $unifiedSelectors = $new;
+            }
+        }
+
+        return $unifiedSelectors;
+    }
+
+    /**
+     * Prepend each selector from $selectors with $parts
+     * @param $selectors
+     * @param $parts
+     * @return array
+     */
+    protected function prependSelectors($selectors, $parts)
+    {
+        $new = [];
+        foreach ($selectors as $compoundSelector) {
+            array_unshift($compoundSelector, $parts);
+            $new[] = $compoundSelector;
+        }
+        return $new;
+    }
+
+    /**
+     * Try to find a matching part in a compound:
+     * - with same html tag name
+     * - with some class or id or something in common
+     * @param array $part
+     * @param array $compound
+     * @return array|bool
+     */
+    protected function matchPartInCompound($part, $compound)
+    {
+        $partTag = $this->findTagName($part);
+        $before = $compound;
+        $after = [];
+        // try to find a match by tag name first
+        while (count($before)) {
+            $p = array_pop($before);
+            if ($partTag && $partTag !== '*' && $partTag == $this->findTagName($p)) {
+                return [$before, $p, $after];
+            }
+            $after[] = $p;
+        }
+        // try again matching a non empty intersection and a compatible tagname
+        $before = $compound;
+        $after = [];
+        while (count($before)) {
+            $p = array_pop($before);
+            if ($this->checkCompatibleTags($partTag, $this->findTagName($p))) {
+                if (count(array_intersect($part, $p))) {
+                    return [$before, $p, $after];
+                }
+            }
+            $after[] = $p;
+        }
+
+        return false;
+    }
+
+    /**
+     * Merge two part list taking care that
+     * - the html tag is coming first - if any
+     * - the :something are coming last
+     *
+     * @param $parts1
+     * @param $parts2
+     * @return array
+     */
+    protected function mergeParts($parts1, $parts2)
+    {
+        $tag1 = $this->findTagName($parts1);
+        $tag2 = $this->findTagName($parts2);
+        $tag = $this->checkCompatibleTags($tag1, $tag2);
+        // not compatible tags
+        if ($tag === false) {
+            return [];
+        }
+
+        if ($tag) {
+            if ($tag1) {
+                $parts1 = array_diff($parts1, [$tag1]);
+            }
+            if ($tag2) {
+                $parts2 = array_diff($parts2, [$tag2]);
+            }
+        }
+
+        $mergedParts = array_merge($parts1, $parts2);
+        $mergedOrderedParts = [];
+        foreach ($mergedParts as $part) {
+            if (strpos($part, ':') === 0) {
+                $mergedOrderedParts[] = $part;
+            }
+        }
+        $mergedParts = array_diff($mergedParts, $mergedOrderedParts);
+        $mergedParts = array_merge($mergedParts, $mergedOrderedParts);
+        if ($tag) {
+            array_unshift($mergedParts, $tag);
+        }
+        return $mergedParts;
+    }
+
+    /**
+     * Check the compatibility between two tag names:
+     * if both are defined they should be identical or one has to be '*'
+     *
+     * @param $tag1
+     * @param $tag2
+     * @return array|bool
+     */
+    protected function checkCompatibleTags($tag1, $tag2)
+    {
+        $tags = [$tag1, $tag2];
+        $tags = array_unique($tags);
+        $tags = array_filter($tags);
+        if (count($tags)>1) {
+            $tags = array_diff($tags, ['*']);
+        }
+        // not compatible nodes
+        if (count($tags)>1) {
+            return false;
+        }
+        return $tags;
+    }
+
+    /**
+     * Find the html tag name in a selector parts list
+     * @param array $parts
+     * @return mixed|string
+     */
+    protected function findTagName($parts)
+    {
+        foreach ($parts as $part) {
+            if (! preg_match('/^[\[.:#%_-]/', $part)) {
+                return $part;
+            }
+        }
+        return '';
+    }
+
     protected static $libSimpleSelectors = ['selector'];
     protected function libSimpleSelectors($args)
     {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6308,4 +6308,23 @@ class Compiler
 
         return $this->formatOutputSelector($selectors);
     }
+
+    protected static $libSimpleSelectors = ['selector'];
+    protected function libSimpleSelectors($args)
+    {
+        $selector = reset($args);
+        $selector = $this->getSelectorArg($selector);
+
+        // remove selectors list layer, keeping the first one
+        $selector = reset($selector);
+        // remove parts list layer, keeping the first part
+        $part = reset($selector);
+
+        $listParts = [];
+        foreach ($part as $p) {
+            $listParts[] = [Type::T_STRING, '', [$p]];
+        }
+
+        return [Type::T_LIST, ',', $listParts];
+    }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1151,8 +1151,7 @@ class Compiler
                 $ec->block = null;
                 $ec->selectors = [];
                 $filtered[] = $ec;
-            }
-            else {
+            } else {
                 $filtered[] = $e;
             }
         }
@@ -6069,7 +6068,8 @@ class Compiler
      * @param array $sub
      * @return bool
      */
-    protected function isSuperSelector($super, $sub) {
+    protected function isSuperSelector($super, $sub)
+    {
         // one and only one selector for each arg
         if (! $super || count($super) !== 1) {
             return false;
@@ -6089,10 +6089,10 @@ class Compiler
             $compound = '';
 
             array_walk_recursive(
-              $node,
-              function ($value, $key) use (&$compound) {
-                  $compound .= $value;
-              }
+                $node,
+                function ($value, $key) use (&$compound) {
+                    $compound .= $value;
+                }
             );
 
             if ($this->isImmediateRelationshipCombinator($compound)) {
@@ -6101,9 +6101,8 @@ class Compiler
                 }
                 $nextMustMatch = true;
                 $i++;
-            }
-            else {
-                while($i<count($sub) && !$this->isSuperPart($node, $sub[$i])) {
+            } else {
+                while ($i < count($sub) && ! $this->isSuperPart($node, $sub[$i])) {
                     if ($nextMustMatch) {
                         return false;
                     }
@@ -6116,6 +6115,7 @@ class Compiler
                 $nextMustMatch = false;
             }
         }
+
         return true;
     }
 
@@ -6125,10 +6125,11 @@ class Compiler
      * @param array $subParts
      * @return bool
      */
-    protected function isSuperPart($superParts, $subParts) {
+    protected function isSuperPart($superParts, $subParts)
+    {
         $i = 0;
         foreach ($superParts as $superPart) {
-            while($i<count($subParts) && $subParts[$i] !== $superPart) {
+            while ($i < count($subParts) && $subParts[$i] !== $superPart) {
                 $i++;
             }
             if ($i >= count($subParts)) {
@@ -6136,6 +6137,7 @@ class Compiler
             }
             $i++;
         }
+
         return true;
     }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6151,7 +6151,7 @@ class Compiler
         return true;
     }
 
-    protected static $libSelectorAppend = ['selector...'];
+    //protected static $libSelectorAppend = ['selector...'];
     protected function libSelectorAppend($args)
     {
         if (count($args) < 1) {
@@ -6236,5 +6236,28 @@ class Compiler
         $this->extendsMap = $saveExtendsMap;
 
         return $this->formatOutputSelector($extended);
+    }
+
+    //protected static $libSelectorNest = ['selector...'];
+    protected function libSelectorNest($args)
+    {
+        if (count($args) < 1) {
+            $this->throwError("selector-nest() needs at least 1 argument");
+        }
+
+        $selectorss = array_map([$this, 'getSelectorArg'], $args);
+
+        $envs = [];
+        foreach ($selectorss as $selectors) {
+            $env = new Environment();
+            $env->selectors = $selectors;
+            $envs[] = $env;
+        }
+
+        $envs = array_reverse($envs);
+        $env = $this->extractEnv($envs);
+        $outputSelectors = $this->multiplySelectors($env);
+
+        return $this->formatOutputSelector($outputSelectors);
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6203,4 +6203,38 @@ class Compiler
 
         return $lastSelectors;
     }
+
+    protected static $libSelectorExtend = ['selectors', 'extendee', 'extender'];
+    protected function libSelectorExtend($args)
+    {
+        list($selectors, $extendee, $extender) = $args;
+        $selectors = $this->getSelectorArg($selectors);
+        $extendee = $this->getSelectorArg($extendee);
+        $extender = $this->getSelectorArg($extender);
+        if (! $selectors || ! $extendee || ! $extender) {
+            $this->throwError("selector-extend() invalid arguments");
+        }
+
+        $saveExtends = $this->extends;
+        $saveExtendsMap = $this->extendsMap;
+
+        $this->extends = [];
+        $this->extendsMap = [];
+
+        foreach ($extendee as $es) {
+            // only use the first one
+            $this->pushExtends(reset($es), $extender, null);
+        }
+
+        $extended = [];
+        foreach ($selectors as $selector) {
+            $extended[] = $selector;
+            $this->matchExtends($selector, $extended);
+        }
+
+        $this->extends = $saveExtends;
+        $this->extendsMap = $saveExtendsMap;
+
+        return $this->formatOutputSelector($extended);
+    }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6260,4 +6260,13 @@ class Compiler
 
         return $this->formatOutputSelector($outputSelectors);
     }
+
+    protected static $libSelectorParse = ['selectors'];
+    protected function libSelectorParse($args)
+    {
+        $selectors = reset($args);
+        $selectors = $this->getSelectorArg($selectors);
+
+        return $this->formatOutputSelector($selectors);
+    }
 }

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -109,3 +109,16 @@
 #{selector-replace(".guide .info", ".info", ".content nav.sidebar")} {
 	content: ".guide .content nav.sidebar, .content .guide nav.sidebar";
 }
+
+#{simple-selectors("a.disabled")} {
+	/* a, .disabled */
+	@each $part in simple-selectors("a.disabled") {
+		content:"#{$part}";
+	}
+}
+#{simple-selectors("main.blog:after")} {
+	/* main, .blog, :after */
+	@each $part in simple-selectors("main.blog:after") {
+		content:"#{$part}";
+	}
+}

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -63,3 +63,14 @@
 #{selector-append(".accordion, .slider", "__copy, __image")} {
 	content:'.accordion__copy, .slider__copy, .accordion__image, .slider__image';
 }
+
+#{selector-extend("a.disabled", "a", ".link")} {
+	content: "a.disabled, .link.disabled";
+}
+#{selector-extend("a.disabled", "h1", "h2")} {
+	content: "a.disabled";
+}
+
+#{selector-extend(".guide .info", ".info", ".content nav.sidebar")} {
+	content: ".guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar";
+}

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -122,3 +122,27 @@
 		content:"#{$part}";
 	}
 }
+
+#{selector-unify("a", ".disabled")} {
+	content:"a.disabled";
+}
+
+#{selector-unify("a.disabled", "a.outgoing")} {
+	content: "a.disabled.outgoing";
+}
+
+#{selector-unify("a", "h1")} {
+	content: "null";
+}
+
+#{selector-unify(".warning a", "main a")} {
+	content: ".warning main a, main .warning a";
+}
+
+#{selector-unify("main.warning a", "main a.disabled")} {
+	content: "main.warning a.disabled";
+}
+
+#{selector-unify("main .warning a", "main a")} {
+	content: "main .warning a";
+}

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -12,3 +12,38 @@
 	}
 }
 
+.is-superselector {
+  content: is-superselector(".is-superselector", ".selector"); /* false */
+}
+.is-superselector1 {
+  content: is-superselector("a", "a.disabled"); /*true*/
+}
+.is-superselector2 {
+  content: is-superselector("a", "a:not(:visited)"); /*true*/
+}
+
+.is-superselector3 {
+  content: is-superselector("a", "a[href]"); /*true*/
+}
+
+.is-superselector4 {
+  content: is-superselector("a.disabled", "a"); /*false*/
+}
+
+.is-superselector5 {
+  content: is-superselector("a.disabled", "a.foo.disabled"); /* true*/
+}
+
+.is-superselector6 {
+  content: is-superselector("a.disabled", "a.foo#disabled"); /* false*/
+}
+
+.is-superselector7 {
+  content: is-superselector("a", "sidebar a"); /* true*/
+}
+.is-superselector8 {
+  content: is-superselector("sidebar a", "a"); /* false*/
+}
+.is-superselector9 {
+  content: is-superselector("a", "a"); /* true*/
+}

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -98,3 +98,14 @@
     }
   }
 }
+
+#{selector-replace("a.disabled", "a", ".link")} {
+	content: ".link.disabled";
+}
+#{selector-replace("a.disabled", "h1", "h2")} {
+	content: "a.disabled";
+}
+
+#{selector-replace(".guide .info", ".info", ".content nav.sidebar")} {
+	content: ".guide .content nav.sidebar, .content .guide nav.sidebar";
+}

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -47,3 +47,19 @@
 .is-superselector9 {
   content: is-superselector("a", "a"); /* true*/
 }
+
+#{selector-append("a", ".disabled")} {
+	content:'a.disabled';
+}
+
+#{selector-append(".accordion", "__copy")} {
+	content:'.accordion__copy';
+}
+
+#{selector-append(".accordion", "__copy, __image")} {
+	content:'.accordion__copy, .accordion__image';
+}
+
+#{selector-append(".accordion, .slider", "__copy, __image")} {
+	content:'.accordion__copy, .slider__copy, .accordion__image, .slider__image';
+}

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -74,3 +74,19 @@
 #{selector-extend(".guide .info", ".info", ".content nav.sidebar")} {
 	content: ".guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar";
 }
+
+#{selector-nest("ul", "li")} {
+	content: "ul li";
+}
+
+#{selector-nest(".alert, .warning", "p")} {
+	content: ".alert p, .warning p";
+}
+
+#{selector-nest(".alert", "&:hover")} {
+	content: ".alert:hover";
+}
+
+#{selector-nest(".accordion", "&__copy")} {
+	content: ".accordion__copy";
+}

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -90,3 +90,11 @@
 #{selector-nest(".accordion", "&__copy")} {
 	content: ".accordion__copy";
 }
+
+@each $selector in selector-parse(".main aside:hover, .sidebar p") {
+  #{$selector} {
+    @each $part in $selector {
+      content: "#{$part}";
+    }
+  }
+}

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -80,3 +80,9 @@ ul li {
 
 .accordion__copy {
   content: ".accordion__copy"; }
+  .main aside:hover {
+    content: ".main";
+    content: "aside:hover"; }
+  .sidebar p {
+    content: ".sidebar";
+    content: "p"; }

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -95,3 +95,14 @@ a.disabled {
 
 .guide .content nav.sidebar, .content .guide nav.sidebar {
   content: ".guide .content nav.sidebar, .content .guide nav.sidebar"; }
+
+a, .disabled {
+  /* a, .disabled */
+  content: "a";
+  content: ".disabled"; }
+
+main, .blog, :after {
+  /* main, .blog, :after */
+  content: "main";
+  content: ".blog";
+  content: ":after"; }

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -47,3 +47,15 @@
 .is-superselector9 {
   content: true;
   /* true*/ }
+
+a.disabled {
+  content: 'a.disabled'; }
+
+.accordion__copy {
+  content: '.accordion__copy'; }
+
+.accordion__copy, .accordion__image {
+  content: '.accordion__copy, .accordion__image'; }
+
+.accordion__copy, .slider__copy, .accordion__image, .slider__image {
+  content: '.accordion__copy, .slider__copy, .accordion__image, .slider__image'; }

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -86,3 +86,12 @@ ul li {
   .sidebar p {
     content: ".sidebar";
     content: "p"; }
+
+.link.disabled {
+  content: ".link.disabled"; }
+
+a.disabled {
+  content: "a.disabled"; }
+
+.guide .content nav.sidebar, .content .guide nav.sidebar {
+  content: ".guide .content nav.sidebar, .content .guide nav.sidebar"; }

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -59,3 +59,12 @@ a.disabled {
 
 .accordion__copy, .slider__copy, .accordion__image, .slider__image {
   content: '.accordion__copy, .slider__copy, .accordion__image, .slider__image'; }
+
+a.disabled, .link.disabled {
+  content: "a.disabled, .link.disabled"; }
+
+a.disabled {
+  content: "a.disabled"; }
+
+.guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar {
+  content: ".guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar"; }

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -68,3 +68,15 @@ a.disabled {
 
 .guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar {
   content: ".guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar"; }
+
+ul li {
+  content: "ul li"; }
+
+.alert p, .warning p {
+  content: ".alert p, .warning p"; }
+
+.alert:hover {
+  content: ".alert:hover"; }
+
+.accordion__copy {
+  content: ".accordion__copy"; }

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -7,3 +7,43 @@
 .main aside:hover, .sidebar p {
   content: ".main aside:hover";
   content: ".sidebar p"; }
+
+.is-superselector {
+  content: false;
+  /* false */ }
+
+.is-superselector1 {
+  content: true;
+  /*true*/ }
+
+.is-superselector2 {
+  content: true;
+  /*true*/ }
+
+.is-superselector3 {
+  content: true;
+  /*true*/ }
+
+.is-superselector4 {
+  content: false;
+  /*false*/ }
+
+.is-superselector5 {
+  content: true;
+  /* true*/ }
+
+.is-superselector6 {
+  content: false;
+  /* false*/ }
+
+.is-superselector7 {
+  content: true;
+  /* true*/ }
+
+.is-superselector8 {
+  content: false;
+  /* false*/ }
+
+.is-superselector9 {
+  content: true;
+  /* true*/ }

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -106,3 +106,21 @@ main, .blog, :after {
   content: "main";
   content: ".blog";
   content: ":after"; }
+
+a.disabled {
+  content: "a.disabled"; }
+
+a.disabled.outgoing {
+  content: "a.disabled.outgoing"; }
+
+ {
+  content: "null"; }
+
+.warning main a, main .warning a {
+  content: ".warning main a, main .warning a"; }
+
+main.warning a.disabled {
+  content: "main.warning a.disabled"; }
+
+main .warning a {
+  content: "main .warning a"; }

--- a/tests/outputs_numbered/selector_functions.css
+++ b/tests/outputs_numbered/selector_functions.css
@@ -89,3 +89,12 @@ ul li {
 .sidebar p {
   content: ".sidebar";
   content: "p"; }
+/* line 102, inputs/selector_functions.scss */
+.link.disabled {
+  content: ".link.disabled"; }
+/* line 105, inputs/selector_functions.scss */
+a.disabled {
+  content: "a.disabled"; }
+/* line 109, inputs/selector_functions.scss */
+.guide .content nav.sidebar, .content .guide nav.sidebar {
+  content: ".guide .content nav.sidebar, .content .guide nav.sidebar"; }

--- a/tests/outputs_numbered/selector_functions.css
+++ b/tests/outputs_numbered/selector_functions.css
@@ -81,3 +81,11 @@ ul li {
 /* line 90, inputs/selector_functions.scss */
 .accordion__copy {
   content: ".accordion__copy"; }
+/* line 95, inputs/selector_functions.scss */
+.main aside:hover {
+  content: ".main";
+  content: "aside:hover"; }
+/* line 95, inputs/selector_functions.scss */
+.sidebar p {
+  content: ".sidebar";
+  content: "p"; }

--- a/tests/outputs_numbered/selector_functions.css
+++ b/tests/outputs_numbered/selector_functions.css
@@ -60,3 +60,12 @@ a.disabled {
 /* line 63, inputs/selector_functions.scss */
 .accordion__copy, .slider__copy, .accordion__image, .slider__image {
   content: '.accordion__copy, .slider__copy, .accordion__image, .slider__image'; }
+/* line 67, inputs/selector_functions.scss */
+a.disabled, .link.disabled {
+  content: "a.disabled, .link.disabled"; }
+/* line 70, inputs/selector_functions.scss */
+a.disabled {
+  content: "a.disabled"; }
+/* line 74, inputs/selector_functions.scss */
+.guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar {
+  content: ".guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar"; }

--- a/tests/outputs_numbered/selector_functions.css
+++ b/tests/outputs_numbered/selector_functions.css
@@ -48,3 +48,15 @@
 .is-superselector9 {
   content: true;
   /* true*/ }
+/* line 51, inputs/selector_functions.scss */
+a.disabled {
+  content: 'a.disabled'; }
+/* line 55, inputs/selector_functions.scss */
+.accordion__copy {
+  content: '.accordion__copy'; }
+/* line 59, inputs/selector_functions.scss */
+.accordion__copy, .accordion__image {
+  content: '.accordion__copy, .accordion__image'; }
+/* line 63, inputs/selector_functions.scss */
+.accordion__copy, .slider__copy, .accordion__image, .slider__image {
+  content: '.accordion__copy, .slider__copy, .accordion__image, .slider__image'; }

--- a/tests/outputs_numbered/selector_functions.css
+++ b/tests/outputs_numbered/selector_functions.css
@@ -109,3 +109,21 @@ main, .blog, :after {
   content: "main";
   content: ".blog";
   content: ":after"; }
+/* line 126, inputs/selector_functions.scss */
+a.disabled {
+  content: "a.disabled"; }
+/* line 130, inputs/selector_functions.scss */
+a.disabled.outgoing {
+  content: "a.disabled.outgoing"; }
+/* line 134, inputs/selector_functions.scss */
+ {
+  content: "null"; }
+/* line 138, inputs/selector_functions.scss */
+.warning main a, main .warning a {
+  content: ".warning main a, main .warning a"; }
+/* line 142, inputs/selector_functions.scss */
+main.warning a.disabled {
+  content: "main.warning a.disabled"; }
+/* line 146, inputs/selector_functions.scss */
+main .warning a {
+  content: "main .warning a"; }

--- a/tests/outputs_numbered/selector_functions.css
+++ b/tests/outputs_numbered/selector_functions.css
@@ -8,3 +8,43 @@
 .main aside:hover, .sidebar p {
   content: ".main aside:hover";
   content: ".sidebar p"; }
+/* line 15, inputs/selector_functions.scss */
+.is-superselector {
+  content: false;
+  /* false */ }
+/* line 18, inputs/selector_functions.scss */
+.is-superselector1 {
+  content: true;
+  /*true*/ }
+/* line 21, inputs/selector_functions.scss */
+.is-superselector2 {
+  content: true;
+  /*true*/ }
+/* line 25, inputs/selector_functions.scss */
+.is-superselector3 {
+  content: true;
+  /*true*/ }
+/* line 29, inputs/selector_functions.scss */
+.is-superselector4 {
+  content: false;
+  /*false*/ }
+/* line 33, inputs/selector_functions.scss */
+.is-superselector5 {
+  content: true;
+  /* true*/ }
+/* line 37, inputs/selector_functions.scss */
+.is-superselector6 {
+  content: false;
+  /* false*/ }
+/* line 41, inputs/selector_functions.scss */
+.is-superselector7 {
+  content: true;
+  /* true*/ }
+/* line 44, inputs/selector_functions.scss */
+.is-superselector8 {
+  content: false;
+  /* false*/ }
+/* line 47, inputs/selector_functions.scss */
+.is-superselector9 {
+  content: true;
+  /* true*/ }

--- a/tests/outputs_numbered/selector_functions.css
+++ b/tests/outputs_numbered/selector_functions.css
@@ -98,3 +98,14 @@ a.disabled {
 /* line 109, inputs/selector_functions.scss */
 .guide .content nav.sidebar, .content .guide nav.sidebar {
   content: ".guide .content nav.sidebar, .content .guide nav.sidebar"; }
+/* line 113, inputs/selector_functions.scss */
+a, .disabled {
+  /* a, .disabled */
+  content: "a";
+  content: ".disabled"; }
+/* line 119, inputs/selector_functions.scss */
+main, .blog, :after {
+  /* main, .blog, :after */
+  content: "main";
+  content: ".blog";
+  content: ":after"; }

--- a/tests/outputs_numbered/selector_functions.css
+++ b/tests/outputs_numbered/selector_functions.css
@@ -69,3 +69,15 @@ a.disabled {
 /* line 74, inputs/selector_functions.scss */
 .guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar {
   content: ".guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar"; }
+/* line 78, inputs/selector_functions.scss */
+ul li {
+  content: "ul li"; }
+/* line 82, inputs/selector_functions.scss */
+.alert p, .warning p {
+  content: ".alert p, .warning p"; }
+/* line 86, inputs/selector_functions.scss */
+.alert:hover {
+  content: ".alert:hover"; }
+/* line 90, inputs/selector_functions.scss */
+.accordion__copy {
+  content: ".accordion__copy"; }


### PR DESCRIPTION
Only `selector-unify()` is missing in the #310 list, but this is not the easiest as the compiler have not yet any internal function doing this job.

I pushed the PR so you can have a look, but I propose waiting it's complete to merge it.

The spec/test cases are taken from https://sass-lang.com/documentation/functions/selector with sometimes some addition for border cases