### PR TITLE
Archive information on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
-# scssphp
-### <http://leafo.github.io/scssphp>
+# This repo has been archived
 
-[![Build](https://travis-ci.org/leafo/scssphp.svg?branch=master)](http://travis-ci.org/leafo/scssphp)
-[![License](https://poser.pugx.org/leafo/scssphp/license.svg)](https://packagist.org/packages/leafo/scssphp)
+
+#### Please go to https://github.com/scssphp/scssphp
+
+----
+
+## scssphp
+<http://leafo.github.io/scssphp>
+
+![License](https://poser.pugx.org/leafo/scssphp/license.svg)
 
 `scssphp` is a compiler for SCSS written in PHP.
 
 Checkout the homepage, <http://leafo.github.io/scssphp>, for directions on how to use.
 
-## Running Tests
+### Running Tests
 
 `scssphp` uses [PHPUnit](https://github.com/sebastianbergmann/phpunit) for testing.
 
@@ -38,7 +44,7 @@ To enable the `scss` compatibility tests:
 
     TEST_SCSS_COMPAT=1 vendor/bin/phpunit tests
 
-## Coding Standard
+### Coding Standard
 
 `scssphp` source conforms to [PSR2](http://www.php-fig.org/psr/psr-2/).
 


### PR DESCRIPTION
Just a last PR here :)

Could be nice to display the archive information on the Readme, as it is more visible, but let you decide if it's acceptable or a bit too much
